### PR TITLE
Fix baleen-javadoc pom for jdk.tools

### DIFF
--- a/baleen/baleen-javadoc/pom.xml
+++ b/baleen/baleen-javadoc/pom.xml
@@ -13,6 +13,8 @@
 	  <groupId>jdk.tools</groupId>
 	  <artifactId>jdk.tools</artifactId>
 	  <version>1.8</version>
+	  <scope>system</scope>
+	  <systemPath>${java.home}/../lib/tools.jar</systemPath>
 	</dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
A small fix to test the pull request process, but fixes a build issue too.

See http://stackoverflow.com/questions/11118070/buiding-hadoop-with-eclipse-maven-missing-artifact-jdk-toolsjdk-toolsjar1