### PR TITLE
Add subtype to entity

### DIFF
--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/MergeAdjacentQuantities.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/MergeAdjacentQuantities.java
@@ -38,7 +38,7 @@ public class MergeAdjacentQuantities extends MergeAdjacent {
 		Quantity q1 = (Quantity) e1;
 		Quantity q2 = (Quantity) e2;
 		
-		return q1.getNormalizedQuantity() >= q2.getNormalizedQuantity() && StringUtils.equals(q1.getQuantityType(), q2.getQuantityType()) && StringUtils.equals(q1.getNormalizedUnit(), q2.getNormalizedUnit());
+		return q1.getNormalizedQuantity() >= q2.getNormalizedQuantity() && StringUtils.equals(q1.getSubType(), q2.getSubType()) && StringUtils.equals(q1.getNormalizedUnit(), q2.getNormalizedUnit());
 	}
 	
 	@Override
@@ -66,7 +66,7 @@ public class MergeAdjacentQuantities extends MergeAdjacent {
 			normalizedQuantity += q.getNormalizedQuantity();
 			
 			setNormalizedUnit(qMerged, q.getNormalizedUnit());
-			setQuantityType(qMerged, q.getQuantityType());
+			setSubType(qMerged, q.getSubType());
 		}
 		
 		qMerged.setNormalizedQuantity(normalizedQuantity);
@@ -80,9 +80,9 @@ public class MergeAdjacentQuantities extends MergeAdjacent {
 		}
 	}
 	
-	private void setQuantityType(Quantity qMerged, String type){
-		if(StringUtils.isBlank(qMerged.getQuantityType())){
-			qMerged.setQuantityType(type);
+	private void setSubType(Quantity qMerged, String type){
+		if(StringUtils.isBlank(qMerged.getSubType())){
+			qMerged.setSubType(type);
 		}
 	}
 }

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/helpers/QuantityUtils.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/helpers/QuantityUtils.java
@@ -65,7 +65,7 @@ public class QuantityUtils {
 			quant.setNormalizedUnit(normalizedUnit);
 		}
 
-		quant.setQuantityType(quantityType);
+		quant.setSubType(quantityType);
 
 		return quant;
 	}

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Custom.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Custom.java
@@ -12,6 +12,8 @@ import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.ResourceInitializationException;
 
+import com.google.common.base.Strings;
+
 import uk.gov.dstl.baleen.core.utils.ConfigUtils;
 import uk.gov.dstl.baleen.exceptions.BaleenException;
 import uk.gov.dstl.baleen.types.semantic.Entity;
@@ -71,6 +73,15 @@ public class Custom extends BaleenAnnotator {
 	private String type = "uk.gov.dstl.baleen.types.semantic.Entity";
 	
 	/**
+	 * The entity subType to use for matched entities
+	 * 
+	 * @baleen.config
+	 */
+	public static final String PARAM_SUB_TYPE = "subType";
+	@ConfigurationParameter(name = PARAM_SUB_TYPE, defaultValue="")
+	private String subType = "";
+	
+	/**
 	 * The confidence to assign to matched entities
 	 * 
 	 * @baleen.config 1.0
@@ -93,7 +104,6 @@ public class Custom extends BaleenAnnotator {
 		}else{
 			p = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
 		}
-		
 		try{
 			et = TypeUtils.getEntityClass(type, JCasFactory.createJCas());
 		}catch(UIMAException | BaleenException e){
@@ -120,6 +130,9 @@ public class Custom extends BaleenAnnotator {
 			ret.setEnd(m.end());
 			
 			ret.setConfidence(confidence);
+			if (!Strings.isNullOrEmpty(subType)) {
+				ret.setSubType(subType);
+			}
 			
 			addToJCasIndex(ret);
 		}

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Email.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Email.java
@@ -31,7 +31,7 @@ public class Email extends AbstractRegexAnnotator<CommsIdentifier> {
 	@Override
 	protected CommsIdentifier create(JCas jCas, Matcher matcher) {
 		CommsIdentifier ci = new CommsIdentifier(jCas);
-		ci.setIdentifierType("email");
+		ci.setSubType("email");
 		return ci;
 	}
 

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/FlightNumber.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/FlightNumber.java
@@ -31,7 +31,7 @@ public class FlightNumber extends AbstractRegexAnnotator<Vehicle> {
 	@Override
 	protected Vehicle create(JCas jCas, Matcher matcher) {
 		Vehicle flight = new Vehicle(jCas);
-		flight.setVehicleType("flight");
+		flight.setSubType("flight");
 		flight.setVehicleIdentifier(matcher.group(2));
 		return flight;
 	}

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/IpV4.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/IpV4.java
@@ -31,7 +31,7 @@ public class IpV4 extends AbstractRegexAnnotator<CommsIdentifier> {
 	@Override
 	protected CommsIdentifier create(JCas jCas, Matcher matcher) {
 		CommsIdentifier ipaddress = new CommsIdentifier(jCas);
-		ipaddress.setIdentifierType("ipv4address");
+		ipaddress.setSubType("ipv4address");
 		return ipaddress;
 	}
 

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/LatLon.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/LatLon.java
@@ -271,7 +271,7 @@ public class LatLon extends BaleenAnnotator {
 					+ coords + "}");
 
 			loc.setCoordinateValue(lon + "," + lat);
-			loc.setCoordinateType(coordinateType);
+			loc.setSubType(coordinateType);
 
 			addToJCasIndex(loc);
 		}

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Mgrs.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Mgrs.java
@@ -67,7 +67,7 @@ public class Mgrs extends BaleenAnnotator {
 			loc.setEnd(matcher.end());
 			loc.setValue(matcher.group(0));
 
-			loc.setCoordinateType("mgrs");
+			loc.setSubType("mgrs");
 
 			enhanceCoordinate(matcher, loc);
 

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Osgb.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Osgb.java
@@ -31,7 +31,7 @@ public class Osgb extends AbstractRegexAnnotator<Coordinate>{
 	@Override
 	protected Coordinate create(JCas jCas, Matcher matcher) {
 		Coordinate loc = new Coordinate(jCas);
-		loc.setCoordinateType("osgb");
+		loc.setSubType("osgb");
 		try {
 			// Attempt to conver to a lat lon
 			double[] en = NationalGrid.fromNationalGrid(matcher.group());

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Postcode.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Postcode.java
@@ -87,7 +87,7 @@ public class Postcode extends AbstractRegexAnnotator<Coordinate> {
 		if(pcLonlat != null){
 			loc.setGeoJson("{\"type\": \"Point\", \"coordinates\": ["+pcLonlat+"]}");
 			loc.setCoordinateValue(pcLonlat);
-			loc.setCoordinateType("postcode");
+			loc.setSubType("postcode");
 			return loc;
 		} else if(postcodes.isEmpty()){
 			return loc;

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Telephone.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/Telephone.java
@@ -30,7 +30,7 @@ public class Telephone extends AbstractRegexAnnotator<CommsIdentifier> {
 	@Override
 	protected CommsIdentifier create(JCas jCas, Matcher matcher) {
 		CommsIdentifier tel = new CommsIdentifier(jCas);
-		tel.setIdentifierType("telephone");
+		tel.setSubType("telephone");
 		return tel;
 
 	}

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/MergeAdjacentQuantitiesTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/MergeAdjacentQuantitiesTest.java
@@ -42,7 +42,7 @@ public class MergeAdjacentQuantitiesTest extends AbstractAnnotatorTest {
 		assertEquals(0.0, q.getQuantity(), 0.0);
 		assertEquals("kg", q.getNormalizedUnit());
 		assertEquals(25.599647, q.getNormalizedQuantity(), 0.0);
-		assertEquals("weight", q.getQuantityType());
+		assertEquals("weight", q.getSubType());
 
 		assertEquals(q3, JCasUtil.selectByIndex(jCas, Quantity.class, 1));
 	}

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/Annotations.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/Annotations.java
@@ -42,7 +42,7 @@ public class Annotations {
 		q.setUnit(unit);
 		q.setNormalizedQuantity(normalizedQuantity);
 		q.setNormalizedUnit("kg");
-		q.setQuantityType(WEIGHT);
+		q.setSubType(WEIGHT);
 		q.addToIndexes();
 		return q;
 	}
@@ -58,7 +58,7 @@ public class Annotations {
 		q.setUnit(unit);
 		q.setNormalizedQuantity(normalizedQuantity);
 		q.setNormalizedUnit("m");
-		q.setQuantityType("length");
+		q.setSubType("length");
 		q.addToIndexes();
 		return q;
 	}

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/types/TestCommsIdentifier.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/types/TestCommsIdentifier.java
@@ -16,7 +16,7 @@ public class TestCommsIdentifier extends TestEntity<CommsIdentifier> {
 	@Override
 	public void validate(CommsIdentifier t) {
 		super.validate(t);
-		assertEquals(identifierType, t.getIdentifierType());
+		assertEquals(identifierType, t.getSubType());
 	}
 	
 }

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/types/TestCoordinate.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/types/TestCoordinate.java
@@ -20,7 +20,7 @@ public class TestCoordinate extends TestAnnotation<Coordinate> {
 	public void validate(Coordinate t) {
 		super.validate(t);
 		
-		assertEquals(coordinateType, t.getCoordinateType());
+		assertEquals(coordinateType, t.getSubType());
 		assertEquals(geometry, t.getGeoJson());
 	}
 

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/types/TestQuantity.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/types/TestQuantity.java
@@ -30,7 +30,7 @@ public class TestQuantity extends TestAnnotation<Quantity> {
 		assertEquals(normalizedQuantity, t.getNormalizedQuantity(), 0.00001);
 		assertEquals(unit, t.getUnit());
 		assertEquals(normalizedUnit, t.getNormalizedUnit());
-		assertEquals(quantityType, t.getQuantityType());
+		assertEquals(quantityType, t.getSubType());
 	}
 
 }

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/types/TestVehicle.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/testing/types/TestVehicle.java
@@ -19,7 +19,7 @@ public class TestVehicle extends TestAnnotation<Vehicle> {
 	public void validate(Vehicle t) {
 		super.validate(t);
 		
-		assertEquals(vehicleType, t.getVehicleType());
+		assertEquals(vehicleType, t.getSubType());
 	}
 
 }

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchConsumerTestBase.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchConsumerTestBase.java
@@ -131,7 +131,7 @@ public class ElasticsearchConsumerTestBase {
 		CommsIdentifier ci = new CommsIdentifier(jCas);
 		ci.setBegin(66);
 		ci.setEnd(83);
-		ci.setIdentifierType("email");
+		ci.setSubType("email");
 		ci.addToIndexes();
 	}
 }

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchTest.java
@@ -159,7 +159,7 @@ public class ElasticsearchTest extends ElasticsearchConsumerTestBase{
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));
 		assertEquals("CommsIdentifier", email.get(TYPE));
-		assertEquals("email", email.get("identifierType"));
+		assertEquals("email", email.get("subType"));
 		assertEquals("james@example.com", email.get(VALUE));
 		assertNotNull(email.get(EXTERNAL_ID));
 	}

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchTest.java
@@ -121,7 +121,7 @@ public class ElasticsearchTest extends ElasticsearchConsumerTestBase{
 		assertEquals(4, entities.size());
 
 		Map<String, Object> person = entities.get(0);
-		assertEquals(7, person.size());
+		assertEquals(8, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -130,7 +130,7 @@ public class ElasticsearchTest extends ElasticsearchConsumerTestBase{
 		assertNotNull(person.get(EXTERNAL_ID));
 
 		Map<String, Object> location = entities.get(1);
-		assertEquals(7, location.size());
+		assertEquals(8, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -145,7 +145,7 @@ public class ElasticsearchTest extends ElasticsearchConsumerTestBase{
 		assertEquals(geometryMap, location.get("geoJson"));
 
 		Map<String, Object> date = entities.get(2);
-		assertEquals(6, date.size());
+		assertEquals(7, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyElasticsearchTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyElasticsearchTest.java
@@ -126,7 +126,7 @@ public class LegacyElasticsearchTest extends ElasticsearchConsumerTestBase {
 		assertEquals(4, entities.size());
 
 		Map<String, Object> person = entities.get(0);
-		assertEquals(7, person.size());
+		assertEquals(8, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -135,7 +135,7 @@ public class LegacyElasticsearchTest extends ElasticsearchConsumerTestBase {
 		assertNotNull(person.get(UNIQUE_ID));
 
 		Map<String, Object> location = entities.get(1);
-		assertEquals(7, location.size());
+		assertEquals(8, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -153,7 +153,7 @@ public class LegacyElasticsearchTest extends ElasticsearchConsumerTestBase {
 		assertEquals(geoJsonMap, location.get("geoJson"));
 
 		Map<String, Object> date = entities.get(2);
-		assertEquals(6, date.size());
+		assertEquals(7, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));
@@ -167,7 +167,7 @@ public class LegacyElasticsearchTest extends ElasticsearchConsumerTestBase {
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));
 		assertEquals("CommsIdentifier", email.get(TYPE));
-		assertEquals("email", email.get("identifierType"));
+		assertEquals("email", email.get("subType"));
 		assertEquals("james@example.com", email.get(VALUE));
 		assertNotNull(email.get(UNIQUE_ID));
 	}

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
@@ -259,7 +259,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals(4, entities.size());
 
 		Map<String, Object> person = (Map<String, Object>)entities.get(0);
-		assertEquals(8, person.size());
+		assertEquals(9, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -267,7 +267,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals("James", person.get(VALUE));
 
 		Map<String, Object> location =(Map<String, Object>) entities.get(1);
-		assertEquals(8, location.size());
+		assertEquals(9, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -279,7 +279,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertArrayEquals(new Double[] { -0.1, 51.5 }, ((BasicDBList)((DBObject)((DBObject)location.get(GEO_JSON)).get("geometry")).get("coordinates")).toArray());
 
 		Map<String, Object> date = (Map<String, Object>)entities.get(2);
-		assertEquals(7, date.size());
+		assertEquals(8, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));
@@ -292,7 +292,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));
 		assertEquals("CommsIdentifier", email.get(TYPE));
-		assertEquals("email", email.get("identifierType"));
+		assertEquals("email", email.get("subType"));
 		assertEquals("james@example.com", email.get(VALUE));
 	}
 

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
@@ -246,7 +246,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		CommsIdentifier ci = new CommsIdentifier(jCas);
 		ci.setBegin(66);
 		ci.setEnd(83);
-		ci.setIdentifierType("email");
+		ci.setSubType("email");
 		ci.setValue("james@example.com");
 		ci.addToIndexes();
 

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/MongoTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/MongoTest.java
@@ -279,7 +279,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> a = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, PERSON));
 		Map<String, Object> person = ((List<Map<String, Object>>)a.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(8, person.size());
+		assertEquals(9, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -288,7 +288,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> b = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, LONDON));
 		Map<String, Object> location = ((List<Map<String, Object>>)b.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(8, location.size());
+		assertEquals(9, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -300,7 +300,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> c = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, DATE));
 		Map<String, Object> date = ((List<Map<String, Object>>)c.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(7, date.size());
+		assertEquals(8, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));
@@ -314,12 +314,12 @@ public class MongoTest extends ConsumerTestBase {
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));
 		assertEquals("CommsIdentifier", email.get(TYPE));
-		assertEquals("email", email.get("identifierType"));
+		assertEquals("email", email.get("subType"));
 		assertEquals(EMAIL, email.get(VALUE));
 		
 		Map<String, Object> e = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, WENT));
 		Map<String, Object> went = ((List<Map<String, Object>>)e.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(8, went.size());
+		assertEquals(9, went.size());
 		assertEquals(6, went.get(BEGIN));
 		assertEquals(10, went.get(END));
 		assertEquals(0.0, went.get(CONFIDENCE));
@@ -446,7 +446,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> a = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, PERSON));
 		Map<String, Object> person = ((List<Map<String, Object>>)a.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(8, person.size());
+		assertEquals(9, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -455,7 +455,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> b = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, LONDON));
 		Map<String, Object> location = ((List<Map<String, Object>>)b.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(8, location.size());
+		assertEquals(9, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -467,7 +467,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> c = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, DATE));
 		Map<String, Object> date = ((List<Map<String, Object>>)c.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(7, date.size());
+		assertEquals(8, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/MongoTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/MongoTest.java
@@ -255,7 +255,7 @@ public class MongoTest extends ConsumerTestBase {
 		CommsIdentifier ci = new CommsIdentifier(jCas);
 		ci.setBegin(66);
 		ci.setEnd(83);
-		ci.setIdentifierType("email");
+		ci.setSubType("email");
 		ci.setValue(EMAIL);
 		ci.addToIndexes();
 		

--- a/baleen/baleen-uima/src/main/java/org/apache/uima/jcas/tcas/DocumentAnnotation.java
+++ b/baleen/baleen-uima/src/main/java/org/apache/uima/jcas/tcas/DocumentAnnotation.java
@@ -17,8 +17,8 @@ import uk.gov.dstl.baleen.exceptions.BaleenException;
 
 
 /** Overriding the base DocumentAnntation to add additional features. The JCasGen code generated from this annotation replaces the default type in uima-document-annotation.jar (which should be removed from the classpath).
- * Updated by JCasGen Thu Feb 26 09:49:58 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/base_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class DocumentAnnotation extends Annotation {
   /** @generated
@@ -278,7 +278,7 @@ public class DocumentAnnotation extends Annotation {
       jcasType.jcas.throwFeatMissing("documentReleasability", "uima.tcas.DocumentAnnotation");
     jcasType.jcas.checkArrayBounds(jcasType.ll_cas.ll_getRefValue(addr, ((DocumentAnnotation_Type)jcasType).casFeatCode_documentReleasability), i);
     jcasType.ll_cas.ll_setStringArrayValue(jcasType.ll_cas.ll_getRefValue(addr, ((DocumentAnnotation_Type)jcasType).casFeatCode_documentReleasability), i, v);}
-        /**
+                        /**
 	 * Get hash of current document text
 	 */
 	public String getHash() {

--- a/baleen/baleen-uima/src/main/java/org/apache/uima/jcas/tcas/DocumentAnnotation_Type.java
+++ b/baleen/baleen-uima/src/main/java/org/apache/uima/jcas/tcas/DocumentAnnotation_Type.java
@@ -14,7 +14,7 @@ import org.apache.uima.cas.impl.FeatureImpl;
 import org.apache.uima.cas.Feature;
 
 /** Overriding the base DocumentAnntation to add additional features. The JCasGen code generated from this annotation replaces the default type in uima-document-annotation.jar (which should be removed from the classpath).
- * Updated by JCasGen Thu Feb 26 09:49:58 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
  * @generated */
 public class DocumentAnnotation_Type extends Annotation_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/BaleenAnnotation.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/BaleenAnnotation.java
@@ -22,8 +22,8 @@ import com.google.common.base.Strings;
 
 
 /** A base class for annotations used by Baleen. Includes things like an internal ID and a function to generate an external ID.
- * Updated by JCasGen Thu Feb 26 09:49:58 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/base_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class BaleenAnnotation extends Annotation {
 	/** @generated
@@ -41,28 +41,28 @@ public class BaleenAnnotation extends Annotation {
 	 */
 	@Override
 	public              int getTypeIndexID() {return typeIndexID;}
-
+ 
 	/** Never called.  Disable default constructor
 	 * @generated */
 	protected BaleenAnnotation() {/* intentionally empty block */}
-
+    
 	/** Internal - constructor used by generator 
 	 * @generated
 	 * @param addr low level Feature Structure reference
 	 * @param type the type of this Feature Structure 
 	 */
 	public BaleenAnnotation(int addr, TOP_Type type) {
-		super(addr, type);
-		readObject();
-	}
-
+    super(addr, type);
+    readObject();
+  }
+  
 	/** @generated
 	 * @param jcas JCas to which this Feature Structure belongs 
 	 */
 	public BaleenAnnotation(JCas jcas) {
-		super(jcas);
-		readObject();   
-	} 
+    super(jcas);
+    readObject();   
+  } 
 
 	/** @generated
 	 * @param jcas JCas to which this Feature Structure belongs
@@ -70,19 +70,19 @@ public class BaleenAnnotation extends Annotation {
 	 * @param end offset to the end spot in the SofA 
 	 */  
 	public BaleenAnnotation(JCas jcas, int begin, int end) {
-		super(jcas);
-		setBegin(begin);
-		setEnd(end);
-		readObject();
-	}   
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
 
-	/** 
-	 * <!-- begin-user-doc -->
+  /** 
+   * <!-- begin-user-doc -->
 	 * Write your own initialization here
 	 * <!-- end-user-doc -->
 	 *
-	 * @generated modifiable 
-	 */
+   * @generated modifiable 
+   */
 	private void readObject() {
 		if(getInternalId() == 0L){
 			IdentityUtils iu = IdentityUtils.getInstance();
@@ -90,32 +90,27 @@ public class BaleenAnnotation extends Annotation {
 		}
 	}
 
-	//*--------------*
-	//* Feature: internalId
+  //*--------------*
+  //* Feature: internalId
 
-	/** getter for internalId - gets An ID that is used internally to refer to the entity
-	 * @generated
-	 * @return value of the feature 
-	 */
+  /** getter for internalId - gets An ID that is used internally to refer to the entity
+   * @generated
+   * @return value of the feature 
+   */
 	public long getInternalId() {
-		if (BaleenAnnotation_Type.featOkTst && ((BaleenAnnotation_Type)jcasType).casFeat_internalId == null)
-			jcasType.jcas.throwFeatMissing("internalId", "uk.gov.dstl.baleen.types.BaleenAnnotation");
-		return jcasType.ll_cas.ll_getLongValue(addr, ((BaleenAnnotation_Type)jcasType).casFeatCode_internalId);}
-
-	/** setter for internalId - sets An ID that is used internally to refer to the entity 
-	 * @generated
-	 * @param v value to set into the feature 
-	 */
+    if (BaleenAnnotation_Type.featOkTst && ((BaleenAnnotation_Type)jcasType).casFeat_internalId == null)
+      jcasType.jcas.throwFeatMissing("internalId", "uk.gov.dstl.baleen.types.BaleenAnnotation");
+    return jcasType.ll_cas.ll_getLongValue(addr, ((BaleenAnnotation_Type)jcasType).casFeatCode_internalId);}
+    
+  /** setter for internalId - sets An ID that is used internally to refer to the entity 
+   * @generated
+   * @param v value to set into the feature 
+   */
 	public void setInternalId(long v) {
-		if(getInternalId() != 0L){
-			LOGGER.warn("Changing the internal ID is not recommended as it may break some aspects of Baleen. Internal ID has been changed from {} to {}.", getInternalId(), v);
-		}
-		if (BaleenAnnotation_Type.featOkTst && ((BaleenAnnotation_Type)jcasType).casFeat_internalId == null)
-			jcasType.jcas.throwFeatMissing("internalId", "uk.gov.dstl.baleen.types.BaleenAnnotation");
-		jcasType.ll_cas.ll_setLongValue(addr, ((BaleenAnnotation_Type)jcasType).casFeatCode_internalId, v);}
-
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(BaleenAnnotation.class);
+    if (BaleenAnnotation_Type.featOkTst && ((BaleenAnnotation_Type)jcasType).casFeat_internalId == null)
+      jcasType.jcas.throwFeatMissing("internalId", "uk.gov.dstl.baleen.types.BaleenAnnotation");
+    jcasType.ll_cas.ll_setLongValue(addr, ((BaleenAnnotation_Type)jcasType).casFeatCode_internalId, v);}    
+                	private static final Logger LOGGER = LoggerFactory.getLogger(BaleenAnnotation.class);
 
 	/**
 	 * Produces an ID that is based on the properties of the current annotation.

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/BaleenAnnotation_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/BaleenAnnotation_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import org.apache.uima.jcas.tcas.Annotation_Type;
 
 /** A base class for annotations used by Baleen. Includes things like an internal ID and a function to generate an external ID.
- * Updated by JCasGen Thu Feb 26 09:49:59 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
  * @generated */
 public class BaleenAnnotation_Type extends Annotation_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/Base.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/Base.java
@@ -9,8 +9,8 @@ import org.apache.uima.jcas.JCasRegistry;
 import org.apache.uima.jcas.cas.TOP_Type;
 
 /** Base annotation with confidence and annotator properties.
- * Updated by JCasGen Thu Feb 26 09:49:59 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/base_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class Base extends BaleenAnnotation {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/Base_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/Base_Type.java
@@ -14,7 +14,7 @@ import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.JCasRegistry;
 
 /** Base annotation with confidence and annotator properties.
- * Updated by JCasGen Thu Feb 26 09:49:59 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
  * @generated */
 public class Base_Type extends BaleenAnnotation_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Buzzword.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Buzzword.java
@@ -13,8 +13,8 @@ import org.apache.uima.jcas.cas.StringArray;
 
 
 /** User-defined key phrases or domain-specific terms, described by a type property.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Buzzword extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Buzzword_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Buzzword_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** User-defined key phrases or domain-specific terms, described by a type property.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Buzzword_Type extends Entity_Type {
   /** @generated 
@@ -80,7 +80,7 @@ public class Buzzword_Type extends Entity_Type {
     if (lowLevelTypeChecks)
       return ll_cas.ll_getStringArrayValue(ll_cas.ll_getRefValue(addr, casFeatCode_tags), i, true);
     jcas.checkArrayBounds(ll_cas.ll_getRefValue(addr, casFeatCode_tags), i);
-	return ll_cas.ll_getStringArrayValue(ll_cas.ll_getRefValue(addr, casFeatCode_tags), i);
+  return ll_cas.ll_getStringArrayValue(ll_cas.ll_getRefValue(addr, casFeatCode_tags), i);
   }
    
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/CommsIdentifier.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/CommsIdentifier.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** A communication identifier - including equipent, user, accounts or subscription.  Includes (but not limited to) the following types: emailAddress, IPv4, IPv6, MSISDN, IMEI, IMSI values.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class CommsIdentifier extends Entity {
   /** @generated
@@ -77,26 +77,6 @@ public class CommsIdentifier extends Entity {
      
  
     
-  //*--------------*
-  //* Feature: identifierType
-
-  /** getter for identifierType - gets A string description of the underlying type of comms identifier described by the annotation type.
-   * @generated
-   * @return value of the feature 
-   */
-  public String getIdentifierType() {
-    if (CommsIdentifier_Type.featOkTst && ((CommsIdentifier_Type)jcasType).casFeat_identifierType == null)
-      jcasType.jcas.throwFeatMissing("identifierType", "uk.gov.dstl.baleen.types.common.CommsIdentifier");
-    return jcasType.ll_cas.ll_getStringValue(addr, ((CommsIdentifier_Type)jcasType).casFeatCode_identifierType);}
-    
-  /** setter for identifierType - sets A string description of the underlying type of comms identifier described by the annotation type. 
-   * @generated
-   * @param v value to set into the feature 
-   */
-  public void setIdentifierType(String v) {
-    if (CommsIdentifier_Type.featOkTst && ((CommsIdentifier_Type)jcasType).casFeat_identifierType == null)
-      jcasType.jcas.throwFeatMissing("identifierType", "uk.gov.dstl.baleen.types.common.CommsIdentifier");
-    jcasType.ll_cas.ll_setStringValue(addr, ((CommsIdentifier_Type)jcasType).casFeatCode_identifierType, v);}    
-  }
+}
 
     

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/CommsIdentifier_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/CommsIdentifier_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** A communication identifier - including equipent, user, accounts or subscription.  Includes (but not limited to) the following types: emailAddress, IPv4, IPv6, MSISDN, IMEI, IMSI values.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class CommsIdentifier_Type extends Entity_Type {
   /** @generated 
@@ -47,32 +47,6 @@ public class CommsIdentifier_Type extends Entity_Type {
   @SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("uk.gov.dstl.baleen.types.common.CommsIdentifier");
  
-  /** @generated */
-  final Feature casFeat_identifierType;
-  /** @generated */
-  final int     casFeatCode_identifierType;
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @return the feature value 
-   */ 
-  public String getIdentifierType(int addr) {
-        if (featOkTst && casFeat_identifierType == null)
-      jcas.throwFeatMissing("identifierType", "uk.gov.dstl.baleen.types.common.CommsIdentifier");
-    return ll_cas.ll_getStringValue(addr, casFeatCode_identifierType);
-  }
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @param v value to set 
-   */    
-  public void setIdentifierType(int addr, String v) {
-        if (featOkTst && casFeat_identifierType == null)
-      jcas.throwFeatMissing("identifierType", "uk.gov.dstl.baleen.types.common.CommsIdentifier");
-    ll_cas.ll_setStringValue(addr, casFeatCode_identifierType, v);}
-    
-  
-
-
-
   /** initialize variables to correspond with Cas Type and Features
 	 * @generated
 	 * @param jcas JCas
@@ -81,10 +55,6 @@ public class CommsIdentifier_Type extends Entity_Type {
   public CommsIdentifier_Type(JCas jcas, Type casType) {
     super(jcas, casType);
     casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl)this.casType, getFSGenerator());
-
- 
-    casFeat_identifierType = jcas.getRequiredFeatureDE(casType, "identifierType", "uima.cas.String", featOkTst);
-    casFeatCode_identifierType  = (null == casFeat_identifierType) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_identifierType).getCode();
 
   }
 }

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/DocumentReference.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/DocumentReference.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** A publication reference/serial/identifier within the source document.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class DocumentReference extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/DocumentReference_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/DocumentReference_Type.java
@@ -13,7 +13,7 @@ import org.apache.uima.cas.Type;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** A publication reference/serial/identifier within the source document.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class DocumentReference_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Frequency.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Frequency.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** A specific frequency value in the electro-magnetic spectrum (Hertz - Hz, MHz, GHz etc.).
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Frequency extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Frequency_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Frequency_Type.java
@@ -13,7 +13,7 @@ import org.apache.uima.cas.Type;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** A specific frequency value in the electro-magnetic spectrum (Hertz - Hz, MHz, GHz etc.).
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Frequency_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Money.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Money.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** Specific amount of some current mentioned within the document.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Money extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Money_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Money_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** Specific amount of some current mentioned within the document.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Money_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Nationality.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Nationality.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** Nationality denonym (e.g. French, British, Spanish)
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Nationality extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Nationality_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Nationality_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** Nationality denonym (e.g. French, British, Spanish)
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Nationality_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Organisation.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Organisation.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** An explicit refrence to a formal organisation, including governmental, political, religious, charitable, economic/financial, business or criminal bodies.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Organisation extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Organisation_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Organisation_Type.java
@@ -13,7 +13,7 @@ import org.apache.uima.cas.Type;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** An explicit refrence to a formal organisation, including governmental, political, religious, charitable, economic/financial, business or criminal bodies.
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Organisation_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Person.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Person.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** A Person named entitiy, as defined by an explict name reference within the source document.
- * Updated by JCasGen Wed Aug 26 12:20:46 BST 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Person extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Person_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Person_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** A Person named entitiy, as defined by an explict name reference within the source document.
- * Updated by JCasGen Wed Aug 26 12:20:46 BST 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Person_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Quantity.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Quantity.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** Type to annotate references to quantities within text
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Quantity extends Entity {
   /** @generated
@@ -163,28 +163,6 @@ public class Quantity extends Entity {
     if (Quantity_Type.featOkTst && ((Quantity_Type)jcasType).casFeat_quantity == null)
       jcasType.jcas.throwFeatMissing("quantity", "uk.gov.dstl.baleen.types.common.Quantity");
     jcasType.ll_cas.ll_setDoubleValue(addr, ((Quantity_Type)jcasType).casFeatCode_quantity, v);}    
-   
-    
-  //*--------------*
-  //* Feature: quantityType
-
-  /** getter for quantityType - gets The type of quantity - e.g. distance, weight, volume, etc.
-   * @generated
-   * @return value of the feature 
-   */
-  public String getQuantityType() {
-    if (Quantity_Type.featOkTst && ((Quantity_Type)jcasType).casFeat_quantityType == null)
-      jcasType.jcas.throwFeatMissing("quantityType", "uk.gov.dstl.baleen.types.common.Quantity");
-    return jcasType.ll_cas.ll_getStringValue(addr, ((Quantity_Type)jcasType).casFeatCode_quantityType);}
-    
-  /** setter for quantityType - sets The type of quantity - e.g. distance, weight, volume, etc. 
-   * @generated
-   * @param v value to set into the feature 
-   */
-  public void setQuantityType(String v) {
-    if (Quantity_Type.featOkTst && ((Quantity_Type)jcasType).casFeat_quantityType == null)
-      jcasType.jcas.throwFeatMissing("quantityType", "uk.gov.dstl.baleen.types.common.Quantity");
-    jcasType.ll_cas.ll_setStringValue(addr, ((Quantity_Type)jcasType).casFeatCode_quantityType, v);}    
   }
 
     

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Quantity_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Quantity_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** Type to annotate references to quantities within text
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Quantity_Type extends Entity_Type {
   /** @generated 
@@ -142,30 +142,6 @@ public class Quantity_Type extends Entity_Type {
     ll_cas.ll_setDoubleValue(addr, casFeatCode_quantity, v);}
     
   
- 
-  /** @generated */
-  final Feature casFeat_quantityType;
-  /** @generated */
-  final int     casFeatCode_quantityType;
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @return the feature value 
-   */ 
-  public String getQuantityType(int addr) {
-        if (featOkTst && casFeat_quantityType == null)
-      jcas.throwFeatMissing("quantityType", "uk.gov.dstl.baleen.types.common.Quantity");
-    return ll_cas.ll_getStringValue(addr, casFeatCode_quantityType);
-  }
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @param v value to set 
-   */    
-  public void setQuantityType(int addr, String v) {
-        if (featOkTst && casFeat_quantityType == null)
-      jcas.throwFeatMissing("quantityType", "uk.gov.dstl.baleen.types.common.Quantity");
-    ll_cas.ll_setStringValue(addr, casFeatCode_quantityType, v);}
-    
-  
 
 
 
@@ -193,10 +169,6 @@ public class Quantity_Type extends Entity_Type {
  
     casFeat_quantity = jcas.getRequiredFeatureDE(casType, "quantity", "uima.cas.Double", featOkTst);
     casFeatCode_quantity  = (null == casFeat_quantity) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_quantity).getCode();
-
- 
-    casFeat_quantityType = jcas.getRequiredFeatureDE(casType, "quantityType", "uima.cas.String", featOkTst);
-    casFeatCode_quantityType  = (null == casFeat_quantityType) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_quantityType).getCode();
 
   }
 }

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Url.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Url.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** A well-formed uniform resource location (URL) value
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Url extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Url_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Url_Type.java
@@ -13,7 +13,7 @@ import org.apache.uima.cas.Type;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** A well-formed uniform resource location (URL) value
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Url_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Vehicle.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Vehicle.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** Specific vehicle or vessel
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
  * @generated */
 public class Vehicle extends Entity {
   /** @generated
@@ -76,28 +76,6 @@ public class Vehicle extends Entity {
   private void readObject() {/*default - does nothing empty block */}
      
  
-    
-  //*--------------*
-  //* Feature: vehicleType
-
-  /** getter for vehicleType - gets The type of vehicle
-   * @generated
-   * @return value of the feature 
-   */
-  public String getVehicleType() {
-    if (Vehicle_Type.featOkTst && ((Vehicle_Type)jcasType).casFeat_vehicleType == null)
-      jcasType.jcas.throwFeatMissing("vehicleType", "uk.gov.dstl.baleen.types.common.Vehicle");
-    return jcasType.ll_cas.ll_getStringValue(addr, ((Vehicle_Type)jcasType).casFeatCode_vehicleType);}
-    
-  /** setter for vehicleType - sets The type of vehicle 
-   * @generated
-   * @param v value to set into the feature 
-   */
-  public void setVehicleType(String v) {
-    if (Vehicle_Type.featOkTst && ((Vehicle_Type)jcasType).casFeat_vehicleType == null)
-      jcasType.jcas.throwFeatMissing("vehicleType", "uk.gov.dstl.baleen.types.common.Vehicle");
-    jcasType.ll_cas.ll_setStringValue(addr, ((Vehicle_Type)jcasType).casFeatCode_vehicleType, v);}    
-   
     
   //*--------------*
   //* Feature: vehicleIdentifier

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Vehicle_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/common/Vehicle_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** Specific vehicle or vessel
- * Updated by JCasGen Tue Feb 03 15:26:49 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:49:26 GMT 2016
  * @generated */
 public class Vehicle_Type extends Entity_Type {
   /** @generated 
@@ -46,30 +46,6 @@ public class Vehicle_Type extends Entity_Type {
      @modifiable */
   @SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("uk.gov.dstl.baleen.types.common.Vehicle");
- 
-  /** @generated */
-  final Feature casFeat_vehicleType;
-  /** @generated */
-  final int     casFeatCode_vehicleType;
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @return the feature value 
-   */ 
-  public String getVehicleType(int addr) {
-        if (featOkTst && casFeat_vehicleType == null)
-      jcas.throwFeatMissing("vehicleType", "uk.gov.dstl.baleen.types.common.Vehicle");
-    return ll_cas.ll_getStringValue(addr, casFeatCode_vehicleType);
-  }
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @param v value to set 
-   */    
-  public void setVehicleType(int addr, String v) {
-        if (featOkTst && casFeat_vehicleType == null)
-      jcas.throwFeatMissing("vehicleType", "uk.gov.dstl.baleen.types.common.Vehicle");
-    ll_cas.ll_setStringValue(addr, casFeatCode_vehicleType, v);}
-    
-  
  
   /** @generated */
   final Feature casFeat_vehicleIdentifier;
@@ -105,10 +81,6 @@ public class Vehicle_Type extends Entity_Type {
   public Vehicle_Type(JCas jcas, Type casType) {
     super(jcas, casType);
     casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl)this.casType, getFSGenerator());
-
- 
-    casFeat_vehicleType = jcas.getRequiredFeatureDE(casType, "vehicleType", "uima.cas.String", featOkTst);
-    casFeatCode_vehicleType  = (null == casFeat_vehicleType) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_vehicleType).getCode();
 
  
     casFeat_vehicleIdentifier = jcas.getRequiredFeatureDE(casType, "vehicleIdentifier", "uima.cas.String", featOkTst);

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/geo/Coordinate.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/geo/Coordinate.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Location;
 
 
 /** A well-formed coordinate value - MGRS or WGS84 DD or DMS cooridate system - explictly defined in source document.
- * Updated by JCasGen Wed Jan 21 12:48:50 GMT 2015
- * XML source: H:/git/core/baleen/baleen-uima/src/main/resources/geo_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:51:56 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/geo_type_system.xml
  * @generated */
 public class Coordinate extends Location {
   /** @generated
@@ -97,28 +97,6 @@ public class Coordinate extends Location {
     if (Coordinate_Type.featOkTst && ((Coordinate_Type)jcasType).casFeat_coordinateValue == null)
       jcasType.jcas.throwFeatMissing("coordinateValue", "uk.gov.dstl.baleen.types.geo.Coordinate");
     jcasType.ll_cas.ll_setStringValue(addr, ((Coordinate_Type)jcasType).casFeatCode_coordinateValue, v);}    
-   
-    
-  //*--------------*
-  //* Feature: coordinateType
-
-  /** getter for coordinateType - gets A designator for the coordinate system of the extracted coordinate value.  Likely to be DD (decimal degree) , DMS (degrees, minutes seconds) or MGRS (military grid reference system) within WGS84.
-   * @generated
-   * @return value of the feature 
-   */
-  public String getCoordinateType() {
-    if (Coordinate_Type.featOkTst && ((Coordinate_Type)jcasType).casFeat_coordinateType == null)
-      jcasType.jcas.throwFeatMissing("coordinateType", "uk.gov.dstl.baleen.types.geo.Coordinate");
-    return jcasType.ll_cas.ll_getStringValue(addr, ((Coordinate_Type)jcasType).casFeatCode_coordinateType);}
-    
-  /** setter for coordinateType - sets A designator for the coordinate system of the extracted coordinate value.  Likely to be DD (decimal degree) , DMS (degrees, minutes seconds) or MGRS (military grid reference system) within WGS84. 
-   * @generated
-   * @param v value to set into the feature 
-   */
-  public void setCoordinateType(String v) {
-    if (Coordinate_Type.featOkTst && ((Coordinate_Type)jcasType).casFeat_coordinateType == null)
-      jcasType.jcas.throwFeatMissing("coordinateType", "uk.gov.dstl.baleen.types.geo.Coordinate");
-    jcasType.ll_cas.ll_setStringValue(addr, ((Coordinate_Type)jcasType).casFeatCode_coordinateType, v);}    
   }
 
     

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/geo/Coordinate_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/geo/Coordinate_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Location_Type;
 
 /** A well-formed coordinate value - MGRS or WGS84 DD or DMS cooridate system - explictly defined in source document.
- * Updated by JCasGen Wed Jan 21 12:48:50 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:51:56 GMT 2016
  * @generated */
 public class Coordinate_Type extends Location_Type {
   /** @generated 
@@ -70,30 +70,6 @@ public class Coordinate_Type extends Location_Type {
     ll_cas.ll_setStringValue(addr, casFeatCode_coordinateValue, v);}
     
   
- 
-  /** @generated */
-  final Feature casFeat_coordinateType;
-  /** @generated */
-  final int     casFeatCode_coordinateType;
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @return the feature value 
-   */ 
-  public String getCoordinateType(int addr) {
-        if (featOkTst && casFeat_coordinateType == null)
-      jcas.throwFeatMissing("coordinateType", "uk.gov.dstl.baleen.types.geo.Coordinate");
-    return ll_cas.ll_getStringValue(addr, casFeatCode_coordinateType);
-  }
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @param v value to set 
-   */    
-  public void setCoordinateType(int addr, String v) {
-        if (featOkTst && casFeat_coordinateType == null)
-      jcas.throwFeatMissing("coordinateType", "uk.gov.dstl.baleen.types.geo.Coordinate");
-    ll_cas.ll_setStringValue(addr, casFeatCode_coordinateType, v);}
-    
-  
 
 
 
@@ -109,10 +85,6 @@ public class Coordinate_Type extends Location_Type {
  
     casFeat_coordinateValue = jcas.getRequiredFeatureDE(casType, "coordinateValue", "uima.cas.String", featOkTst);
     casFeatCode_coordinateValue  = (null == casFeat_coordinateValue) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_coordinateValue).getCode();
-
- 
-    casFeat_coordinateType = jcas.getRequiredFeatureDE(casType, "coordinateType", "uima.cas.String", featOkTst);
-    casFeatCode_coordinateType  = (null == casFeat_coordinateType) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_coordinateType).getCode();
 
   }
 }

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/military/MilitaryPlatform.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/military/MilitaryPlatform.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.semantic.Entity;
 
 
 /** A reference to a military platform - space, air, land, surface and sub-surface platforms, where the type platform is described as a property.
- * Updated by JCasGen Tue Feb 03 15:25:17 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/military_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:52:23 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/military_type_system.xml
  * @generated */
 public class MilitaryPlatform extends Entity {
   /** @generated
@@ -77,26 +77,6 @@ public class MilitaryPlatform extends Entity {
      
  
     
-  //*--------------*
-  //* Feature: platformType
-
-  /** getter for platformType - gets The platform type
-   * @generated
-   * @return value of the feature 
-   */
-  public String getPlatformType() {
-    if (MilitaryPlatform_Type.featOkTst && ((MilitaryPlatform_Type)jcasType).casFeat_platformType == null)
-      jcasType.jcas.throwFeatMissing("platformType", "uk.gov.dstl.baleen.types.military.MilitaryPlatform");
-    return jcasType.ll_cas.ll_getStringValue(addr, ((MilitaryPlatform_Type)jcasType).casFeatCode_platformType);}
-    
-  /** setter for platformType - sets The platform type 
-   * @generated
-   * @param v value to set into the feature 
-   */
-  public void setPlatformType(String v) {
-    if (MilitaryPlatform_Type.featOkTst && ((MilitaryPlatform_Type)jcasType).casFeat_platformType == null)
-      jcasType.jcas.throwFeatMissing("platformType", "uk.gov.dstl.baleen.types.military.MilitaryPlatform");
-    jcasType.ll_cas.ll_setStringValue(addr, ((MilitaryPlatform_Type)jcasType).casFeatCode_platformType, v);}    
-  }
+}
 
     

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/military/MilitaryPlatform_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/military/MilitaryPlatform_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.semantic.Entity_Type;
 
 /** A reference to a military platform - space, air, land, surface and sub-surface platforms, where the type platform is described as a property.
- * Updated by JCasGen Tue Feb 03 15:25:17 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:52:23 GMT 2016
  * @generated */
 public class MilitaryPlatform_Type extends Entity_Type {
   /** @generated 
@@ -47,32 +47,6 @@ public class MilitaryPlatform_Type extends Entity_Type {
   @SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("uk.gov.dstl.baleen.types.military.MilitaryPlatform");
  
-  /** @generated */
-  final Feature casFeat_platformType;
-  /** @generated */
-  final int     casFeatCode_platformType;
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @return the feature value 
-   */ 
-  public String getPlatformType(int addr) {
-        if (featOkTst && casFeat_platformType == null)
-      jcas.throwFeatMissing("platformType", "uk.gov.dstl.baleen.types.military.MilitaryPlatform");
-    return ll_cas.ll_getStringValue(addr, casFeatCode_platformType);
-  }
-  /** @generated
-   * @param addr low level Feature Structure reference
-   * @param v value to set 
-   */    
-  public void setPlatformType(int addr, String v) {
-        if (featOkTst && casFeat_platformType == null)
-      jcas.throwFeatMissing("platformType", "uk.gov.dstl.baleen.types.military.MilitaryPlatform");
-    ll_cas.ll_setStringValue(addr, casFeatCode_platformType, v);}
-    
-  
-
-
-
   /** initialize variables to correspond with Cas Type and Features
 	 * @generated
 	 * @param jcas JCas
@@ -81,10 +55,6 @@ public class MilitaryPlatform_Type extends Entity_Type {
   public MilitaryPlatform_Type(JCas jcas, Type casType) {
     super(jcas, casType);
     casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl)this.casType, getFSGenerator());
-
- 
-    casFeat_platformType = jcas.getRequiredFeatureDE(casType, "platformType", "uima.cas.String", featOkTst);
-    casFeatCode_platformType  = (null == casFeat_platformType) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_platformType).getCode();
 
   }
 }

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity.java
@@ -13,8 +13,8 @@ import uk.gov.dstl.baleen.types.Base;
 
 
 /** Type to represent named entities - values that are assigned a semantic type.
- * Updated by JCasGen Thu Feb 05 12:06:54 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class Entity extends Base implements Recordable {
   @SuppressWarnings ("hiding")
@@ -29,11 +29,11 @@ public class Entity extends Base implements Recordable {
    */
   @Override
   public              int getTypeIndexID() {return typeIndexID;}
-
+ 
   /** Never called.  Disable default constructor
    * @generated */
   protected Entity() {/* intentionally empty block */}
-
+    
   /** Internal - constructor used by generator
    * @generated
    * @param addr low level Feature Structure reference
@@ -43,14 +43,14 @@ public class Entity extends Base implements Recordable {
     super(addr, type);
     readObject();
   }
-
+  
   /** @generated
    * @param jcas JCas to which this Feature Structure belongs
    */
   public Entity(JCas jcas) {
     super(jcas);
-    readObject();
-  }
+    readObject();   
+  } 
 
   /** @generated
    * @param jcas JCas to which this Feature Structure belongs
@@ -62,14 +62,14 @@ public class Entity extends Base implements Recordable {
     setBegin(begin);
     setEnd(end);
     readObject();
-  }
+  }   
 
-  /**
+  /** 
    * <!-- begin-user-doc -->
    * Write your own initialization here
    * <!-- end-user-doc -->
    *
-   * @generated modifiable
+   * @generated modifiable 
    */
   private void readObject() {/*default - does nothing empty block */}
 
@@ -78,46 +78,64 @@ public class Entity extends Base implements Recordable {
 
   /** getter for value - gets A value which reflects the name of the entity. May or may not differ from underlying span from the document.
    * @generated
-   * @return value of the feature
+   * @return value of the feature 
    */
   public String getValue() {
-    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_value == null) {
-		jcasType.jcas.throwFeatMissing("value", "uk.gov.dstl.baleen.types.semantic.Entity");
-	}
+    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_value == null)
+      jcasType.jcas.throwFeatMissing("value", "uk.gov.dstl.baleen.types.semantic.Entity");
     return jcasType.ll_cas.ll_getStringValue(addr, ((Entity_Type)jcasType).casFeatCode_value);}
-
-  /** setter for value - sets A value which reflects the name of the entity. May or may not differ from underlying span from the document.
+    
+  /** setter for value - sets A value which reflects the name of the entity. May or may not differ from underlying span from the document. 
    * @generated
-   * @param v value to set into the feature
+   * @param v value to set into the feature 
    */
   public void setValue(String v) {
-    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_value == null) {
-		jcasType.jcas.throwFeatMissing("value", "uk.gov.dstl.baleen.types.semantic.Entity");
-	}
-    jcasType.ll_cas.ll_setStringValue(addr, ((Entity_Type)jcasType).casFeatCode_value, v);}
-
-
+    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_value == null)
+      jcasType.jcas.throwFeatMissing("value", "uk.gov.dstl.baleen.types.semantic.Entity");
+    jcasType.ll_cas.ll_setStringValue(addr, ((Entity_Type)jcasType).casFeatCode_value, v);}    
+   
+    
   //*--------------*
   //* Feature: referent
 
   /** getter for referent - gets Can be used to link a corefence to an entity to another (presuambly more definitive) mention of the same entity elsewhere in the text.
    * @generated
-   * @return value of the feature
+   * @return value of the feature 
    */
   public ReferenceTarget getReferent() {
-    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_referent == null) {
-		jcasType.jcas.throwFeatMissing("referent", "uk.gov.dstl.baleen.types.semantic.Entity");
-	}
-    return (ReferenceTarget)jcasType.ll_cas.ll_getFSForRef(jcasType.ll_cas.ll_getRefValue(addr, ((Entity_Type)jcasType).casFeatCode_referent));}
-
-  /** setter for referent - sets Can be used to link a corefence to an entity to another (presuambly more definitive) mention of the same entity elsewhere in the text.
+    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_referent == null)
+      jcasType.jcas.throwFeatMissing("referent", "uk.gov.dstl.baleen.types.semantic.Entity");
+    return (ReferenceTarget)(jcasType.ll_cas.ll_getFSForRef(jcasType.ll_cas.ll_getRefValue(addr, ((Entity_Type)jcasType).casFeatCode_referent)));}
+    
+  /** setter for referent - sets Can be used to link a corefence to an entity to another (presuambly more definitive) mention of the same entity elsewhere in the text. 
    * @generated
-   * @param v value to set into the feature
+   * @param v value to set into the feature 
    */
   public void setReferent(ReferenceTarget v) {
-    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_referent == null) {
-		jcasType.jcas.throwFeatMissing("referent", "uk.gov.dstl.baleen.types.semantic.Entity");
-	}
-    jcasType.ll_cas.ll_setRefValue(addr, ((Entity_Type)jcasType).casFeatCode_referent, jcasType.ll_cas.ll_getFSRef(v));}
+    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_referent == null)
+      jcasType.jcas.throwFeatMissing("referent", "uk.gov.dstl.baleen.types.semantic.Entity");
+    jcasType.ll_cas.ll_setRefValue(addr, ((Entity_Type)jcasType).casFeatCode_referent, jcasType.ll_cas.ll_getFSRef(v));}    
+   
+    
+  //*--------------*
+  //* Feature: subType
+
+  /** getter for subType - gets String identifying sub type of entity.
+   * @generated
+   * @return value of the feature 
+   */
+  public String getSubType() {
+    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_subType == null)
+      jcasType.jcas.throwFeatMissing("subType", "uk.gov.dstl.baleen.types.semantic.Entity");
+    return jcasType.ll_cas.ll_getStringValue(addr, ((Entity_Type)jcasType).casFeatCode_subType);}
+    
+  /** setter for subType - sets String identifying sub type of entity. 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setSubType(String v) {
+    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_subType == null)
+      jcasType.jcas.throwFeatMissing("subType", "uk.gov.dstl.baleen.types.semantic.Entity");
+    jcasType.ll_cas.ll_setStringValue(addr, ((Entity_Type)jcasType).casFeatCode_subType, v);}    
   }
 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.Base_Type;
 
 /** Type to represent named entities - values that are assigned a semantic type.
- * Updated by JCasGen Thu Feb 05 12:06:54 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
  * @generated */
 public class Entity_Type extends Base_Type {
   /** @generated 
@@ -94,6 +94,30 @@ public class Entity_Type extends Base_Type {
     ll_cas.ll_setRefValue(addr, casFeatCode_referent, v);}
     
   
+ 
+  /** @generated */
+  final Feature casFeat_subType;
+  /** @generated */
+  final int     casFeatCode_subType;
+  /** @generated
+   * @param addr low level Feature Structure reference
+   * @return the feature value 
+   */ 
+  public String getSubType(int addr) {
+        if (featOkTst && casFeat_subType == null)
+      jcas.throwFeatMissing("subType", "uk.gov.dstl.baleen.types.semantic.Entity");
+    return ll_cas.ll_getStringValue(addr, casFeatCode_subType);
+  }
+  /** @generated
+   * @param addr low level Feature Structure reference
+   * @param v value to set 
+   */    
+  public void setSubType(int addr, String v) {
+        if (featOkTst && casFeat_subType == null)
+      jcas.throwFeatMissing("subType", "uk.gov.dstl.baleen.types.semantic.Entity");
+    ll_cas.ll_setStringValue(addr, casFeatCode_subType, v);}
+    
+  
 
 
 
@@ -113,6 +137,10 @@ public class Entity_Type extends Base_Type {
  
     casFeat_referent = jcas.getRequiredFeatureDE(casType, "referent", "uk.gov.dstl.baleen.types.semantic.ReferenceTarget", featOkTst);
     casFeatCode_referent  = (null == casFeat_referent) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_referent).getCode();
+
+ 
+    casFeat_subType = jcas.getRequiredFeatureDE(casType, "subType", "uima.cas.String", featOkTst);
+    casFeatCode_subType  = (null == casFeat_subType) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_subType).getCode();
 
   }
 }

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Event.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Event.java
@@ -11,8 +11,8 @@ import org.apache.uima.jcas.cas.TOP_Type;
 
 
 /** An temporal interaction of interest, covering political, organisational, miltiary, criminal or social interactions mentioned within the document.
- * Updated by JCasGen Thu Feb 05 12:06:54 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class Event extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Event_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Event_Type.java
@@ -14,7 +14,7 @@ import org.apache.uima.cas.impl.FeatureImpl;
 import org.apache.uima.cas.Feature;
 
 /** An temporal interaction of interest, covering political, organisational, miltiary, criminal or social interactions mentioned within the document.
- * Updated by JCasGen Thu Feb 05 12:06:54 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
  * @generated */
 public class Event_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Location.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Location.java
@@ -11,8 +11,8 @@ import org.apache.uima.jcas.cas.TOP_Type;
 
 
 /** A reference to a place, country, administrative region or geo-political entity within the source document. This is a general purpose type that is extended in "geo" types.
- * Updated by JCasGen Thu Feb 05 12:06:55 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class Location extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Location_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Location_Type.java
@@ -14,7 +14,7 @@ import org.apache.uima.cas.impl.FeatureImpl;
 import org.apache.uima.cas.Feature;
 
 /** A reference to a place, country, administrative region or geo-political entity within the source document. This is a general purpose type that is extended in "geo" types.
- * Updated by JCasGen Thu Feb 05 12:06:55 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:31 GMT 2016
  * @generated */
 public class Location_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/ReferenceTarget.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/ReferenceTarget.java
@@ -11,8 +11,8 @@ import org.apache.uima.jcas.tcas.Annotation;
 
 
 /** A target type for the referent property, such that entities pointing to the same target are assumed to be coreferences. The target can therefore be thought of as a super-entity, though it has no properties or value of it's own. The span of this entity is taken to be the scope in which this reference target is valid.
- * Updated by JCasGen Thu Feb 05 12:06:55 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:31 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class ReferenceTarget extends Annotation {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/ReferenceTarget_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/ReferenceTarget_Type.java
@@ -13,7 +13,7 @@ import org.apache.uima.jcas.JCasRegistry;
 import org.apache.uima.jcas.tcas.Annotation_Type;
 
 /** A target type for the referent property, such that entities pointing to the same target are assumed to be coreferences. The target can therefore be thought of as a super-entity, though it has no properties or value of it's own. The span of this entity is taken to be the scope in which this reference target is valid.
- * Updated by JCasGen Thu Feb 05 12:06:55 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:31 GMT 2016
  * @generated */
 public class ReferenceTarget_Type extends Annotation_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Relation.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Relation.java
@@ -12,8 +12,8 @@ import uk.gov.dstl.baleen.types.Base;
 
 
 /** Records a relationship between named entities, explicitly mentioned within the source document.
- * Updated by JCasGen Thu Feb 05 12:06:55 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:31 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class Relation extends Base {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Relation_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Relation_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.Base_Type;
 
 /** Records a relationship between named entities, explicitly mentioned within the source document.
- * Updated by JCasGen Thu Feb 05 12:06:55 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:31 GMT 2016
  * @generated */
 public class Relation_Type extends Base_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Temporal.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Temporal.java
@@ -11,8 +11,8 @@ import org.apache.uima.jcas.cas.TOP_Type;
 
 
 /** General type to record temporal (time based) information mentioned within the document.  This is a general purpose type that is extended in "time" types.
- * Updated by JCasGen Thu Feb 05 12:06:55 GMT 2015
- * XML source: H:/git/TextProcessing/core/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+ * Updated by JCasGen Fri Feb 05 14:54:31 GMT 2016
+ * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class Temporal extends Entity {
   /** @generated

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Temporal_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Temporal_Type.java
@@ -12,7 +12,7 @@ import org.apache.uima.cas.impl.TypeImpl;
 import org.apache.uima.cas.Type;
 
 /** General type to record temporal (time based) information mentioned within the document.  This is a general purpose type that is extended in "time" types.
- * Updated by JCasGen Thu Feb 05 12:06:55 GMT 2015
+ * Updated by JCasGen Fri Feb 05 14:54:31 GMT 2016
  * @generated */
 public class Temporal_Type extends Entity_Type {
   /** @generated 

--- a/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
+++ b/baleen/baleen-uima/src/main/resources/types/common_type_system.xml
@@ -21,11 +21,6 @@ This XML file classified as UK OFFICIAL.</description>
       <description>Specific vehicle or vessel</description>
       <supertypeName>uk.gov.dstl.baleen.types.semantic.Entity</supertypeName>
       <features>
-        <featureDescription>
-          <name>vehicleType</name>
-          <description>The type of vehicle</description>
-          <rangeTypeName>uima.cas.String</rangeTypeName>
-        </featureDescription>
       <featureDescription>
           <name>vehicleIdentifier</name>
           <description>An identifying name or number for the vehicle</description>
@@ -110,11 +105,6 @@ This XML file classified as UK OFFICIAL.</description>
           <description>The raw quantity</description>
           <rangeTypeName>uima.cas.Double</rangeTypeName>
         </featureDescription>
-      <featureDescription>
-          <name>quantityType</name>
-          <description>The type of quantity - e.g. distance, weight, volume, etc.</description>
-          <rangeTypeName>uima.cas.String</rangeTypeName>
-        </featureDescription>
       </features>
     </typeDescription>
   <typeDescription>
@@ -133,13 +123,6 @@ This XML file classified as UK OFFICIAL.</description>
       <name>uk.gov.dstl.baleen.types.common.CommsIdentifier</name>
       <description>A communication identifier - including equipent, user, accounts or subscription.  Includes (but not limited to) the following types: emailAddress, IPv4, IPv6, MSISDN, IMEI, IMSI values.</description>
       <supertypeName>uk.gov.dstl.baleen.types.semantic.Entity</supertypeName>
-      <features>
-        <featureDescription>
-          <name>identifierType</name>
-          <description>A string description of the underlying type of comms identifier described by the annotation type.</description>
-          <rangeTypeName>uima.cas.String</rangeTypeName>
-        </featureDescription>
-      </features>
     </typeDescription>
   <typeDescription>
       <name>uk.gov.dstl.baleen.types.common.DocumentReference</name>

--- a/baleen/baleen-uima/src/main/resources/types/geo_type_system.xml
+++ b/baleen/baleen-uima/src/main/resources/types/geo_type_system.xml
@@ -21,11 +21,6 @@ This XML file classified as UK OFFICIAL.</description>
           <description>A normalised value for the coordinate.</description>
           <rangeTypeName>uima.cas.String</rangeTypeName>
         </featureDescription>
-        <featureDescription>
-          <name>coordinateType</name>
-          <description>A designator for the coordinate system of the extracted coordinate value.  Likely to be DD (decimal degree) , DMS (degrees, minutes seconds) or MGRS (military grid reference system) within WGS84.</description>
-          <rangeTypeName>uima.cas.String</rangeTypeName>
-        </featureDescription>
       </features>
     </typeDescription>
   </types>

--- a/baleen/baleen-uima/src/main/resources/types/military_type_system.xml
+++ b/baleen/baleen-uima/src/main/resources/types/military_type_system.xml
@@ -15,13 +15,6 @@ This XML file classified as UK OFFICIAL.</description>
       <name>uk.gov.dstl.baleen.types.military.MilitaryPlatform</name>
       <description>A reference to a military platform - space, air, land, surface and sub-surface platforms, where the type platform is described as a property.</description>
       <supertypeName>uk.gov.dstl.baleen.types.semantic.Entity</supertypeName>
-      <features>
-        <featureDescription>
-          <name>platformType</name>
-          <description>The platform type</description>
-          <rangeTypeName>uima.cas.String</rangeTypeName>
-        </featureDescription>
-      </features>
     </typeDescription>
     </types>
 </typeSystemDescription>

--- a/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+++ b/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
@@ -25,6 +25,11 @@ This XML file classified as UK OFFICIAL.</description>
           <description>Can be used to link a corefence to an entity to another (presuambly more definitive) mention of the same entity elsewhere in the text.</description>
           <rangeTypeName>uk.gov.dstl.baleen.types.semantic.ReferenceTarget</rangeTypeName>
         </featureDescription>
+        <featureDescription>
+          <name>subType</name>
+          <description>String identifying sub type of entity.</description>
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
       </features>
     </typeDescription>
     <typeDescription>

--- a/baleen/baleen-uima/src/test/java/uk/gov/dstl/baleen/types/BaleenAnnotationTest.java
+++ b/baleen/baleen-uima/src/test/java/uk/gov/dstl/baleen/types/BaleenAnnotationTest.java
@@ -37,7 +37,7 @@ public class BaleenAnnotationTest {
 		CommsIdentifier ci = new CommsIdentifier(jCas);
 		ci.setBegin(16);
 		ci.setEnd(31);
-		ci.setIdentifierType("email");
+		ci.setSubType("email");
 		ci.addToIndexes();
 		
 		assertEquals(currId + 4, ci.getInternalId());


### PR DESCRIPTION
Belated, first pull-request from Roke (the largest of ~27). Adds generic subtype to all Entities. This allows annotators to create specific subtypes of all Entities and enables cleaners that can be configured for all entities types and subtypes. Potential exists in the future to replace subtypes with labels or tag hierarchies enabling a more flexible generic solution but the subtype change adds sufficient flexibility for now without introducing complexity.