### PR TITLE
Fixed issue in TOLocationEntity to correctly stop a location search

### DIFF
--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/grammatical/TOLocationEntity.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/grammatical/TOLocationEntity.java
@@ -40,6 +40,11 @@ public class TOLocationEntity extends BaleenAnnotator {
 		for(int j = firstToken + 1; j < tokens.size(); j++){
 			if("NNP".equals(tokens.get(j).getPartOfSpeech())){
 				end = tokens.get(j).getEnd();
+			} else {
+				// Finished sequence of contiguous NNP following VBD, TO,
+				// Need to stop now or may encounter another NNP elsewhere
+				// in the document that has nothing to do with this location.
+				break;
 			}
 		}
 		

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/TOLocationEntityTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/TOLocationEntityTest.java
@@ -67,6 +67,14 @@ public class TOLocationEntityTest extends AbstractAnnotatorTest {
 	}
 	
 	@Test
+	public void testFollowingNNP() throws UIMAException {
+		jCas.setDocumentText("James went to South London to ride the London Eye.");
+		process();
+
+		assertAnnotations(1, Location.class, new TestEntity<>(0, "South London"));
+	}
+
+	@Test
 	public void testEndOfSentence() throws UIMAException {
 		jCas.setDocumentText("James went to London");
 		process();


### PR DESCRIPTION
The TOLocationEntity annotator identifies locations by looking for a VBD TO NNP part of speech pattern, where the NNP represents the location.

The original version of the code searches all the WordToken annotations in the document for NNP tokens starting at the one that forms part of a VBD, TO, NNP sequence. This means that it matches on the last NNP token it encounters. So the sentence: "James went to South London to ride the London Eye." results in a location of "South London to ride the London Eye", rather than "South London".

This has been fixed to stop looking for NNP tokens as soon as the last contiguous one (to the curent token sequence) has been reached. This results in the correct location string being produced.