### PR TITLE
Changes to the way regular expressions work in CleanPunctuation and T…

### DIFF
--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/CleanPunctuation.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/CleanPunctuation.java
@@ -28,7 +28,7 @@ import uk.gov.dstl.baleen.uima.BaleenAnnotator;
  * 
  */
 public class CleanPunctuation extends BaleenAnnotator {
-	private static final String ALLOWED_CHARACTERS_START_END = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789()£$€";
+	private static final String ALLOWED_CHARACTERS_START_END = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789()£$€-";
 
 	@Override
 	public void doProcess(JCas jCas) throws AnalysisEngineProcessException {

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/internals/TimeRegex.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/internals/TimeRegex.java
@@ -29,7 +29,8 @@ public class TimeRegex extends AbstractRegexAnnotator<Time> {
 			.collect(Collectors.toList()),
 		"|");
 	
-    private static final String TIME_REGEX = "\\b(((0?[0-9])|([0-9]{2}))[:][0-9]{2}\\h*(("+TIME_ZONES+")([ ]?[+-][ ]?((0?[0-9])|(1[0-2])))?)?\\h*(pm|am)?)\\b|\\b(((1[0-2])|([1-9]))(pm|am))\\b|\\b(midnight)\\b|\\b(midday)\\b|\\b((12\\h)?noon)\\b|\\b([0-2][0-9][0-5][0-9][ ]?(hr(s)?)?[ ]?(("+TIME_ZONES+")([ ]?[+-][ ]?((0?[0-9])|(1[0-2])))?)?)\\b";	
+	private static final String TIME_REGEX = "\\b(([0-1]?[0-9]|2[0-4])[:\\.][0-5][0-9]\\h*(("+TIME_ZONES+")([ ]?[+-][ ]?((0?[0-9])|(1[0-2])))?)?\\h*(pm|am)?)\\b|\\b(((1[0-2])|([1-9]))(pm|am))\\b|\\b(midnight)\\b|\\b(midday)\\b|\\b((12\\h)?noon)\\b|\\b([0-1][0-9]|2[0-4])[0-5][0-9][ ]?(((hr(s)?)?[ ]?(("+TIME_ZONES+")([ ]?[+-][ ]?((0?[0-9])|(1[0-2])))?)?)|hours|h)\\b";
+	
 	/** New instance.
 	 * 
 	 */


### PR DESCRIPTION
This branch contains some minor regex updates from the CCD-DE project. It consists of two separate main parts:

1. CleanPunctuation.java can now accept a dash ("-") at either the beginning or end of an entity. An example of where this is useful is in accepting negative values such as -$30.00.

2. TimeRegex.java now only accepts times between 0:00 and 24:59:59. Both 0 and 24 are accepted for midnight. This class can now recognise times separated by dots (".") as well as colons (":"). Additionally, xxxxh and xxxxhours notation is now accepted, so "0700h" will be recognised as a time entity. Changes to this class honour DSTL's changes to this class for Baleen 2.1.