### PR TITLE
Fixed corrupt document handling

### DIFF
--- a/baleen/baleen-collectionreaders/src/main/java/uk/gov/dstl/baleen/contentextractors/TikaContentExtractor.java
+++ b/baleen/baleen-collectionreaders/src/main/java/uk/gov/dstl/baleen/contentextractors/TikaContentExtractor.java
@@ -10,15 +10,17 @@ import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.BodyContentHandler;
 import org.apache.uima.jcas.JCas;
+import org.elasticsearch.common.base.Strings;
 import org.xml.sax.SAXException;
 
 import uk.gov.dstl.baleen.contentextractors.helpers.AbstractContentExtractor;
 
-/** 
- * Extracts metadata and text content from the supplied input, using Apache Tika.
+/** Extracts metadata and text content from the supplied input, using Apache Tika.
+ * 
+ *
  */
 public class TikaContentExtractor extends AbstractContentExtractor {
-
+	public static final String CORRUPT_FILE_TEXT = "FILE CONTENTS CORRUPT - UNABLE TO PROCESS";
 	@Override
 	public void doProcessStream(InputStream stream, String source, JCas jCas) throws IOException {
 		super.doProcessStream(stream, source, jCas);
@@ -38,6 +40,9 @@ public class TikaContentExtractor extends AbstractContentExtractor {
 			}
 		} catch (SAXException | TikaException e) {
 			getMonitor().warn("Couldn't parse metadata from '{}'", source, e);
+			if (Strings.isNullOrEmpty(jCas.getDocumentText())) {
+				jCas.setDocumentText(CORRUPT_FILE_TEXT);
+			}
 		}
 	}
 }

--- a/baleen/baleen-collectionreaders/src/test/java/uk/gov/dstl/baleen/contentextractors/TikaContentExtractorTest.java
+++ b/baleen/baleen-collectionreaders/src/test/java/uk/gov/dstl/baleen/contentextractors/TikaContentExtractorTest.java
@@ -2,7 +2,6 @@
 package uk.gov.dstl.baleen.contentextractors;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -117,6 +116,6 @@ public class TikaContentExtractorTest {
 		}
 		contentExtractor.destroy();
 		
-		assertNull(jCas.getDocumentText());
+		assertEquals(TikaContentExtractor.CORRUPT_FILE_TEXT, jCas.getDocumentText());
 	}
 }


### PR DESCRIPTION
Previously, Baleen would write the message "'FILE CONTENTS CORRUPT - UNABLE TO PROCESS" to the JCas for any corrupt documents. The corresponding test would then assert that the JCas text was null. This fix makes sure that the JCas keeps this message and modifies the corresponding test to make sure that the JCas text equals this message.