### PR TITLE
Provide normalize cleaners

### DIFF
--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeDates.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeDates.java
@@ -1,0 +1,151 @@
+package uk.gov.dstl.baleen.annotators.cleaners;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+
+import uk.gov.dstl.baleen.annotators.cleaners.helpers.AbstractNormalizeEntities;
+import uk.gov.dstl.baleen.types.semantic.Entity;
+import uk.gov.dstl.baleen.types.temporal.DateType;
+
+/**
+ * Formats the value of the DateType entities to a standard form for consistent representation
+ * on export. If it is unable to parse the value then it returns the original string. Significantly
+ * if avoids formatting dates where the actual reference is ambiguous and this includes all dates
+ * with only a two digit year specifier, given that the century is indeterminable. An assumption
+ * could be made but the user with the rest of the document contents is better placed to make it.
+ * @baleen.javadoc
+ * 
+ */
+public class NormalizeDates extends AbstractNormalizeEntities {
+	
+	/**
+	 * What is the format that the dates should be normalized to? The default value follows the 
+	 * ISO8601 standard.
+	 * @baleen.config yyyy'-'MM'-'dd
+	 */
+	public static final String PARAM_DATE_FORMAT = "correctFormat";
+	@ConfigurationParameter(name = PARAM_DATE_FORMAT, defaultValue = "yyyy'-'MM'-'dd")
+	String correctFormat;
+	
+	private boolean orderAmbiguityFlag = false;
+
+	@Override
+	protected String normalize(Entity e) {
+		String dateString = e.getValue();
+		
+		/*Flag is reset to avoid giving a false positive for the date that is about to be
+		* processed. Good practice for calling classes would be to get this flag as soon
+		* after the call to normalize the date as is possible, if it is desired.
+		*/
+		orderAmbiguityFlag = false;
+
+		//Format the received string to remove suffixes, day names and normalise delimiters
+		String cleanedDateString = dateString.replaceAll("[./-]", " ");
+		cleanedDateString = cleanedDateString.replaceAll("(Mon|Tues|Wed|Wednes|Thurs|Fri|Sat|Satur|Sun)(day)? ", "");
+		cleanedDateString = cleanedDateString.replaceAll("[ ]{2,}", " ");
+	
+		SimpleDateFormat formatter = new SimpleDateFormat("d' 'M' 'yyyy", Locale.ENGLISH);
+
+		//Pattern catches numeric dates in possible British order day, month, year
+		if (cleanedDateString.matches("(0?[1-9]|[12][0-9]|3[01]) (0?[1-9]|1[012]) [0-9]{4}")) {
+			
+			if (cleanedDateString.matches("(0?[1-9]|1[012]) (0?[1-9]|1[012]) [0-9]{4}")) {
+				orderAmbiguityFlag = true;
+			}
+			
+			try {
+				Date date = formatter.parse(cleanedDateString);
+				formatter.applyPattern(correctFormat);
+				return formatter.format(date);
+			}
+			catch (ParseException exception) {
+				return dateString;
+			}
+			
+		}
+		//Pattern catches numeric dates definitely in American order month, day, year
+		else if (cleanedDateString.matches("(0?[1-9]|1[012]) (0?[1-9]|[12][0-9]|3[01]) [0-9]{4}")) {
+
+			try {
+				formatter.applyPattern("M' 'd' 'yyyy")	;
+				Date date = formatter.parse(cleanedDateString);
+				formatter.applyPattern(correctFormat);
+				return formatter.format(date);
+			}
+			catch (ParseException exception) {
+				return dateString;
+			}
+			
+		}
+		//Pattern catches numeric dates in ISO standard order year, month, day
+		else if (cleanedDateString.matches("[0-9]{4} [0-1]?[0-9] [0-9]{1,2}")) {
+
+			try {
+				formatter.applyPattern("yyyy' 'M' 'd")	;
+				Date date = formatter.parse(cleanedDateString);
+				formatter.applyPattern(correctFormat);
+				return formatter.format(date);
+			}
+			catch (ParseException exception) {
+				return dateString;
+			}
+			
+		}
+		else {
+			cleanedDateString = cleanedDateString.replaceAll("(nd|rd|th)", "");
+			cleanedDateString = cleanedDateString.replaceAll("1st", "1");
+			formatter.applyPattern("d' 'MMM' 'yyyy");
+			
+			//Pattern matches dates in British order day, month, year
+			if (cleanedDateString.matches("(0?[1-9]|[12][0-9]|3[01]) .+ [0-9]{4}")) {
+				
+				try {
+					Date date = formatter.parse(cleanedDateString);
+					formatter.applyPattern(correctFormat);
+					return formatter.format(date);
+				}
+				catch (ParseException exception) {
+					return dateString;
+				}
+				
+			}
+			//Pattern catches dates in American order month, day, year
+			else if (cleanedDateString.matches(".+ (0?[1-9]|[12][0-9]|3[01]) [0-9]{4}")){
+				
+				try {
+					formatter.applyPattern("MMM' 'd' 'yyyy");
+					Date date = formatter.parse(cleanedDateString);
+					formatter.applyPattern(correctFormat);;
+					return formatter.format(date);
+				}
+				catch (ParseException exception) {
+					return dateString;
+				}
+			}
+			else {
+				return dateString;
+			}
+		}
+	
+	}
+	
+	/**
+	 * Method to get the value of the orderAmbiguityFlag.
+	 * @return orderAmbiguityFlag is a boolean that is true if the most recently parsed date
+	 * is ambiguous as to whether it is ordered Day/Month/Year or Month/Day/Year
+	 * @baleen.javadoc
+	 */
+	public boolean getOrderAmbiguityFlag() {
+		return orderAmbiguityFlag; 
+	}
+
+	@Override
+	protected boolean shouldNormalize(Entity e) {
+		return e instanceof DateType;
+	}
+
+}

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeOSGB.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeOSGB.java
@@ -1,0 +1,28 @@
+package uk.gov.dstl.baleen.annotators.cleaners;
+
+import uk.gov.dstl.baleen.annotators.cleaners.helpers.AbstractNormalizeEntities;
+import uk.gov.dstl.baleen.types.geo.Coordinate;
+import uk.gov.dstl.baleen.types.semantic.Entity;
+
+/**
+ * Formats the value of the OSGB entities to be consistent for export and entity
+ * matching between documents. The format is two upper case letters followed by
+ * an even digit number with no whitespace or other characters.
+ * @baleen.javadoc
+ * 
+ */
+public class NormalizeOSGB extends AbstractNormalizeEntities {
+	
+	@Override
+	protected String normalize(Entity e) {
+		String osgb = e.getValue();
+		osgb = osgb.replaceAll("[\\s]", "");
+		osgb = osgb.toUpperCase();
+		return osgb;
+	}
+
+	@Override
+	protected boolean shouldNormalize(Entity e) {
+		return ((e instanceof Coordinate) && (e.getSubType().equals("osgb")));
+	}
+}

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeTimes.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeTimes.java
@@ -1,0 +1,181 @@
+package uk.gov.dstl.baleen.annotators.cleaners;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
+
+import uk.gov.dstl.baleen.annotators.cleaners.helpers.AbstractNormalizeEntities;
+import uk.gov.dstl.baleen.types.semantic.Entity;
+import uk.gov.dstl.baleen.types.temporal.Time;
+
+/**
+ * Edits the value field of Time entities (separate from time entities which are a quantity) to a
+ * consistent format, for ease of entity comparison between documents and consistent data representation
+ * on export. The format is set as the 24 hour representation of the time followed by an upper-case acronym
+ * of the time zone +/- an integer number of hours as an offset. The zone and offset are both optional,
+ * only preserved from the original value, never added or changed to be in a different zone and separated
+ * from the time by a single space. Zones are only recognised if they are an acronym in the set of zone IDs
+ * available from the TimeZone class.
+ * @baleen.javadoc
+ * 
+  */
+public class NormalizeTimes extends AbstractNormalizeEntities{
+
+	/* Create a list of time zone acronyms to use in the regular expressions. This is the same list as is used
+	 * by the time regex annotator to find times.
+	 */
+	private static final String TIME_ZONES = StringUtils.join(
+			Arrays.asList(TimeZone.getAvailableIDs())
+				.stream().filter(s -> StringUtils.isAllUpperCase(s) && s.length() <= 3)
+				.collect(Collectors.toList()),"|");
+	
+	private static final String TO24HR = "HH:mm";
+	
+	@Override
+	protected String normalize(Entity e) {
+		String timeString = e.getValue();
+		SimpleDateFormat formatter = new SimpleDateFormat("yy H:m a z");
+		Date timeObj = null;
+		
+		//Pattern catches keywords with a known time
+		Pattern pKeyWords = Pattern.compile("(midday)|(noon)|(midnight)",Pattern.CASE_INSENSITIVE);
+		Matcher mKeyWords = pKeyWords.matcher(timeString);
+		
+		//One of the regex patterns used by the time annotator. Captures 12/24 hour time formats with/without
+		//am/pm marker or time zone.
+		Pattern p12Hour = Pattern.compile("\\b((([0-1]?[0-9])|2[0-4])[:\\.][0-5][0-9])\\h*(("
+				+ TIME_ZONES + ")([ ]?[+-][ ]?((0?[0-9])|(1[0-2])))?)?\\h*(pm|am)?\\b",Pattern.CASE_INSENSITIVE);
+		Matcher m12Hour = p12Hour.matcher(timeString);
+		
+		//Another of the regex patterns, this captures simple 12 hour format times with no minute values
+		Pattern pSimple = Pattern.compile("((1[0-2])|([1-9]))(pm|am)",Pattern.CASE_INSENSITIVE);
+		Matcher mSimple = pSimple.matcher(timeString);
+		
+		if (mKeyWords.find()) {
+			if (!(mKeyWords.group(1) == null) || !(mKeyWords.group(2) == null)) {
+				return "12:00";
+			} else {
+				return "00:00";
+			}
+		}
+		else if (m12Hour.matches()) {
+			/* the prefix '15 ' is used to set the year. This is an arbitrary value, special only in that it
+			 * is not the default year the formatter chooses, 1970. Using this default year, times with the GMT
+			 * timeObj zone specified are interpreted with +1 hour e.g. 01:00 GMT AM is interpreted as 02:00 GMT
+			 * AM by the formatter. This may have something to do with the Double Summer Time experiment which
+			 * ran from 1968 - 1971.
+			 */
+			StringBuilder timeSb = new StringBuilder("15 " + m12Hour.group(1).replaceAll("\\.", ":"));
+			
+			if (m12Hour.group(10) != null) {
+				timeSb.append(" " + m12Hour.group(10));
+				
+				try {
+					if (m12Hour.group(5) != null) {
+						/* Neither "H:m a" or "h:m a" can correctly identify all timeStrings. The former will parse
+						 * 03:01 pm as 03:01 am whilst the latter will interpret 17:01 pm as 05:01 am. The following
+						 * check switches the pattern depending on whether the hours part of the string denote
+						 * an integer that is < than 12.
+						 */
+						if (Integer.parseInt(timeSb.substring(3, timeSb.length() - 6)) < 12)
+							formatter.applyPattern("yy K:m a z");
+						
+						timeSb.append(" " + m12Hour.group(5));
+						timeObj = formatter.parse(timeSb.toString());
+						formatter.applyPattern(TO24HR + " z");
+					} else {
+						formatter.applyPattern("yy H:m a");
+						if (Integer.parseInt(timeSb.substring(3, timeSb.length() - 6)) < 12)
+							formatter.applyPattern("yy K:m a");
+						
+						timeObj = formatter.parse(timeSb.toString());
+						formatter.applyPattern(TO24HR);
+					}
+				} catch (ParseException exception) {
+					System.out.printf("h# Parse Exception occurred 1 %d %s\n",exception.getErrorOffset(),exception.getMessage());
+					return timeString;
+				}
+				
+			} else {
+				
+				try {
+					if (m12Hour.group(5) != null) {
+						timeSb.append(" " + m12Hour.group(5));
+						formatter.applyPattern("yy H:m z");
+						timeObj = formatter.parse(timeSb.toString());
+						formatter.applyPattern(TO24HR + " z");
+					} else {
+						formatter.applyPattern("yy H:m");
+						timeObj = formatter.parse(timeSb.toString());
+						formatter.applyPattern(TO24HR);
+					}
+				} catch (ParseException exception) {
+					System.out.printf("h# Parse Exception occurred 2 %d %s",exception.getErrorOffset(),exception.getMessage());
+					return timeString;
+				}
+				
+			}
+			
+			//Replace string builder contents with formatted output
+			timeSb.delete(0, timeSb.length());
+			timeSb.append(formatter.format(timeObj));
+			
+			if (m12Hour.group(6) != null) {
+				String cleanedSubstring = m12Hour.group(6).replaceAll("[\\s]", "");
+				cleanedSubstring = cleanedSubstring.replaceAll("\\+0", "+");
+				cleanedSubstring = cleanedSubstring.replaceAll("-0", "-");
+				timeSb.append(cleanedSubstring);
+			}
+			
+			return timeSb.toString();
+		}
+		else if (mSimple.matches()) {
+			
+			try {
+				formatter.applyPattern("hha");
+				timeObj = formatter.parse(timeString);
+				formatter.applyPattern(TO24HR);
+			} catch (ParseException exception) {
+				System.out.printf("h# Parse Exception occurred 2 %d %s",exception.getErrorOffset(),exception.getMessage());
+				return timeString;
+			}
+			
+			return formatter.format(timeObj);
+		} 
+		//This default scenario handles the remaining 24 hour formats: '2400 time zone (+offset)?' or '2400 h/hours'
+		else {
+			StringBuilder timeSb = new StringBuilder(timeString.substring(0, 2) + ":" + timeString.substring(2, 4));
+			
+			//Correct this particular case
+			if (timeString.substring(0,2).equals("24"))
+				timeSb.replace(0, 2, "00");
+			
+			String cleanedSubstring = timeString.substring(4,timeString.length()).replaceAll("[\\s]", "");
+			cleanedSubstring = cleanedSubstring.replaceAll("\\+0", "+");
+			cleanedSubstring = cleanedSubstring.replaceAll("-0", "-");
+			cleanedSubstring = cleanedSubstring.toUpperCase();
+			
+			//In this case the substring is not part of the standard output so drop it
+			if (cleanedSubstring.matches("H|HOURS")) {
+				return timeSb.toString();
+			} else {
+				cleanedSubstring = cleanedSubstring.replaceAll("\\+$", "");	//In case of +0 offsets don't leave a dangling '+'
+				timeSb.append(" " + cleanedSubstring);
+				return timeSb.toString();
+			}
+			
+		}
+	}
+	
+	@Override
+	protected boolean shouldNormalize(Entity e) {
+		return (e instanceof Time);
+	}
+}

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeWhitespace.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeWhitespace.java
@@ -1,35 +1,22 @@
 //Dstl (c) Crown Copyright 2015
 package uk.gov.dstl.baleen.annotators.cleaners;
 
-import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
-import org.apache.uima.cas.FSIterator;
-import org.apache.uima.jcas.JCas;
-import org.apache.uima.jcas.tcas.Annotation;
-
-import com.google.common.base.Strings;
-
+import uk.gov.dstl.baleen.annotators.cleaners.helpers.AbstractNormalizeEntities;
 import uk.gov.dstl.baleen.types.semantic.Entity;
-import uk.gov.dstl.baleen.uima.BaleenAnnotator;
 
 /**
  * Replace blocks of whitespace with a single space (this includes new lines) in the value
  * 
- * 
  */
-public class NormalizeWhitespace extends BaleenAnnotator {
+public class NormalizeWhitespace extends AbstractNormalizeEntities {
+
 	@Override
-	public void doProcess(JCas jCas) throws AnalysisEngineProcessException {
-		
-		FSIterator<Annotation> iter = jCas.getAnnotationIndex(Entity.type).iterator();
-		while(iter.hasNext()){
-			Entity e = (Entity) iter.next();
-			
-			if(Strings.isNullOrEmpty(e.getValue())){
-				getMonitor().debug("No value set for entity '{}' - skipping", e.getCoveredText());
-				continue;
-			}
-			
-			e.setValue(e.getValue().replaceAll("[\n\\h]+", " "));
-		}
+	protected boolean shouldNormalize(Entity e) {
+		return true;
+	}
+
+	@Override
+	protected String normalize(Entity e) {
+		return e.getValue().replaceAll("[\n\\h]+", " ");
 	}
 }

--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/helpers/AbstractNormalizeEntities.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/helpers/AbstractNormalizeEntities.java
@@ -1,0 +1,57 @@
+package uk.gov.dstl.baleen.annotators.cleaners.helpers;
+
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.cas.FSIterator;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+
+import uk.gov.dstl.baleen.types.semantic.Entity;
+import uk.gov.dstl.baleen.uima.BaleenAnnotator;
+
+import com.google.common.base.Strings;
+
+/**
+ * A class for containing the generic functionality shared by all normalizing
+ * cleaners. Both methods are intended to be overridden with operations specific
+ * to the entities handled by a particular child cleaner.
+ * @baleen.javadoc
+ * 
+ */
+public abstract class AbstractNormalizeEntities extends BaleenAnnotator {
+
+	public void doProcess(JCas jCas) throws AnalysisEngineProcessException {
+
+		FSIterator<Annotation> iter = jCas.getAnnotationIndex(Entity.type).iterator();
+
+		while (iter.hasNext()) {
+			Entity e = (Entity) iter.next();
+
+			if (Strings.isNullOrEmpty(e.getValue())) {
+				getMonitor().debug("No value set for entity '{}' - skipping", e.getCoveredText());
+				continue;
+			}
+
+			if (this.shouldNormalize(e)) {
+				String normalized = this.normalize(e);
+				if (!normalized.equals(e.getValue())) {
+					e.setValue(normalized);
+					e.setIsNormalised(true);
+				}
+			}
+
+		}
+	}
+	
+	/**
+	 * The shouldNormalize method is used first to identify entities of the type
+	 * the cleaner is supposed to operate on.
+	 */
+	protected abstract boolean shouldNormalize(Entity e);
+
+	/**
+	 * Overridden with the specific operations required to calculate the normalized
+	 * value of the entity. If it is not possible to normalize this method should return
+	 * the original value of the entity.
+	 */
+	protected abstract String normalize(Entity e);
+}

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDDRegexTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDDRegexTest.java
@@ -35,6 +35,20 @@ public class LatLonDDRegexTest extends AbstractAnnotatorTest{
 	}
 	
 	@Test
+	public void testNoDelimiter() throws Exception{
+	
+		jCas.setDocumentText("London is located in the UK, at 51.507, -0.125. Edinburgh is also in the UK, at 55.953,-3.188. The following coordinates aren't valid: 87.65432.1; 12.3-56.789.");
+		processJCas();
+		
+		
+		assertAnnotations(2, Coordinate.class,
+				new TestCoordinate(0, "51.507, -0.125", "dd", TYPE_POINT_COORDINATES_0_125_51_507),
+				new TestCoordinate(1, "55.953,-3.188", "dd", TYPE_POINT_COORDINATES_3_188_55_953)
+		);
+
+	}
+	
+	@Test
 	public void testLonlat() throws Exception{
 		
 		jCas.setDocumentText("London is located in the UK, at -0.125, 51.507. Edinburgh is also in the UK, at -3.188,55.953.");

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDDRegexTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDDRegexTest.java
@@ -1,6 +1,9 @@
 //Dstl (c) Crown Copyright 2015
 package uk.gov.dstl.baleen.annotators;
 
+import static org.junit.Assert.assertEquals;
+
+import org.apache.uima.fit.util.JCasUtil;
 import org.junit.Test;
 
 import uk.gov.dstl.baleen.annotators.regex.LatLon;
@@ -15,6 +18,8 @@ public class LatLonDDRegexTest extends AbstractAnnotatorTest{
 	
 	private static final String TYPE_POINT_COORDINATES_0_125_51_507 = "{\"type\":\"Point\",\"coordinates\":[-0.125,51.507]}";
 	private static final String TYPE_POINT_COORDINATES_3_188_55_953 = "{\"type\":\"Point\",\"coordinates\":[-3.188,55.953]}";
+	private static final String TYPE_POINT_COORDINATES_75_0152_09_190 = "{\"type\":\"Point\",\"coordinates\":[-75.0152,-9.19]}";
+	private static final String TYPE_POINT_COORDINATES_127_766_35_907 = "{\"type\":\"Point\",\"coordinates\":[127.7669,35.9078]}";
 
 	public LatLonDDRegexTest() {
 		super(LatLon.class);
@@ -71,6 +76,158 @@ public class LatLonDDRegexTest extends AbstractAnnotatorTest{
 				new TestCoordinate(0, "51.507, -0.125", "dd", TYPE_POINT_COORDINATES_0_125_51_507)
 		);
 
+	}
+	
+	@Test
+	public void testDegreeSym() throws Exception{
+		String docText = "London is located in the UK, at 51.507°, -0.125°. Edinburgh is also in the UK, at 55.9530,-3.1880."
+				+ "But darkest Peru is at -9.19°, -75.0152° and South Korea at 35.9078°, 127.7669°.";
+		jCas.setDocumentText(docText);
+		processJCas();
+		
+		
+		assertAnnotations(4, Coordinate.class,
+				new TestCoordinate(0, "51.507°, -0.125°", "dd", TYPE_POINT_COORDINATES_0_125_51_507),
+				new TestCoordinate(1, "55.9530,-3.1880", "dd", TYPE_POINT_COORDINATES_3_188_55_953),
+				new TestCoordinate(2, "-9.19°, -75.0152°", "dd", TYPE_POINT_COORDINATES_75_0152_09_190),
+				new TestCoordinate(3, "35.9078°, 127.7669°", "dd", TYPE_POINT_COORDINATES_127_766_35_907)
+		);
+
+	}
+	
+	@Test
+	public void testCardinalSym() throws Exception{
+		String docText = "London is located in the UK, at 51.507° N, 0.125°W. Edinburgh is also in the UK, at 55.9530°N,3.1880° W."
+				+ "But darkest Peru is at 9.19° S, 75.0152°W and South Korea at 35.9078°N, 127.7669° E.";
+		jCas.setDocumentText(docText);
+		processJCas();
+		
+		
+		assertAnnotations(4, Coordinate.class,
+				new TestCoordinate(0, "51.507° N, 0.125°W", "dd", TYPE_POINT_COORDINATES_0_125_51_507),
+				new TestCoordinate(1, "55.9530°N,3.1880° W", "dd", TYPE_POINT_COORDINATES_3_188_55_953),
+				new TestCoordinate(2, "9.19° S, 75.0152°W", "dd", TYPE_POINT_COORDINATES_75_0152_09_190),
+				new TestCoordinate(3, "35.9078°N, 127.7669° E", "dd", TYPE_POINT_COORDINATES_127_766_35_907)
+		);
+
+		Coordinate t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals(false, t.getIsNormalised());
+	}
+	
+	@Test
+	public void testNormalize() throws Exception{
+		String docText = "London is located in the UK, at 51.507° N, 0.125°W. Edinburgh is also in the UK, at 55.9530°N,3.1880° W."
+				+ "But darkest Peru is at 9.19° S, 75.0152°W and South Korea at 35.9078°N, 127.7669° E.";
+		jCas.setDocumentText(docText);
+		processJCas("storeDecimalValue", true);
+		
+		
+		assertAnnotations(4, Coordinate.class,
+				new TestCoordinate(0, "51.507° N, 0.125°W", "dd", TYPE_POINT_COORDINATES_0_125_51_507),
+				new TestCoordinate(1, "55.9530°N,3.1880° W", "dd", TYPE_POINT_COORDINATES_3_188_55_953),
+				new TestCoordinate(2, "9.19° S, 75.0152°W", "dd", TYPE_POINT_COORDINATES_75_0152_09_190),
+				new TestCoordinate(3, "35.9078°N, 127.7669° E", "dd", TYPE_POINT_COORDINATES_127_766_35_907)
+		);
+
+		Coordinate t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals("51.507 -0.125", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 1);
+		assertEquals("55.953 -3.188", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 2);
+		assertEquals("-9.19 -75.0152", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 3);
+		assertEquals("35.9078 127.7669", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+	}
+	
+	@Test
+	public void testNormalizeCardinal() throws Exception{
+		String docText = "London is located in the UK, at 51.507° N, 0.125°W. Edinburgh is also in the UK, at 55.9530°N,3.1880° W."
+				+ "But darkest Peru is at 9.19° S, 75.0152°W and South Korea at 35.9078°N, 127.7669° E.";
+		jCas.setDocumentText(docText);
+		processJCas("storeDecimalValue", true, "storeCardinalPoint", true);
+		
+		
+		assertAnnotations(4, Coordinate.class,
+				new TestCoordinate(0, "51.507° N, 0.125°W", "dd", TYPE_POINT_COORDINATES_0_125_51_507),
+				new TestCoordinate(1, "55.9530°N,3.1880° W", "dd", TYPE_POINT_COORDINATES_3_188_55_953),
+				new TestCoordinate(2, "9.19° S, 75.0152°W", "dd", TYPE_POINT_COORDINATES_75_0152_09_190),
+				new TestCoordinate(3, "35.9078°N, 127.7669° E", "dd", TYPE_POINT_COORDINATES_127_766_35_907)
+		);
+
+		Coordinate t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals("51.507N 0.125W", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 1);
+		assertEquals("55.953N 3.188W", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 2);
+		assertEquals("9.19S 75.0152W", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 3);
+		assertEquals("35.9078N 127.7669E", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+	}
+	
+	@Test
+	public void testNormalizeLonFirst() throws Exception{
+		String docText = "London is located in the UK, at 51.507° N, 0.125°W. Edinburgh is also in the UK, at 55.9530°N,3.1880° W."
+				+ "But darkest Peru is at 9.19° S, 75.0152°W and South Korea at 35.9078°N, 127.7669° E.";
+		jCas.setDocumentText(docText);
+		processJCas("storeDecimalValue", true, "storeLongitudeFirst", true);
+		
+		
+		assertAnnotations(4, Coordinate.class,
+				new TestCoordinate(0, "51.507° N, 0.125°W", "dd", TYPE_POINT_COORDINATES_0_125_51_507),
+				new TestCoordinate(1, "55.9530°N,3.1880° W", "dd", TYPE_POINT_COORDINATES_3_188_55_953),
+				new TestCoordinate(2, "9.19° S, 75.0152°W", "dd", TYPE_POINT_COORDINATES_75_0152_09_190),
+				new TestCoordinate(3, "35.9078°N, 127.7669° E", "dd", TYPE_POINT_COORDINATES_127_766_35_907)
+		);
+
+		Coordinate t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals("-0.125 51.507", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 1);
+		assertEquals("-3.188 55.953", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 2);
+		assertEquals("-75.0152 -9.19", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 3);
+		assertEquals("127.7669 35.9078", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+	}
+	
+	@Test
+	public void testNormalizeLonFirstCard() throws Exception{
+		String docText = "London is located in the UK, at 51.507° N, 0.125°W. Edinburgh is also in the UK, at 55.9530°N,3.1880° W."
+				+ "But darkest Peru is at 9.19° S, 75.0152°W and South Korea at 35.9078°N, 127.7669° E.";
+		jCas.setDocumentText(docText);
+		processJCas("storeDecimalValue", true, "storeCardinalPoint", true, "storeLongitudeFirst", true);
+		
+		
+		assertAnnotations(4, Coordinate.class,
+				new TestCoordinate(0, "51.507° N, 0.125°W", "dd", TYPE_POINT_COORDINATES_0_125_51_507),
+				new TestCoordinate(1, "55.9530°N,3.1880° W", "dd", TYPE_POINT_COORDINATES_3_188_55_953),
+				new TestCoordinate(2, "9.19° S, 75.0152°W", "dd", TYPE_POINT_COORDINATES_75_0152_09_190),
+				new TestCoordinate(3, "35.9078°N, 127.7669° E", "dd", TYPE_POINT_COORDINATES_127_766_35_907)
+		);
+
+		Coordinate t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals("0.125W 51.507N", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 1);
+		assertEquals("3.188W 55.953N", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 2);
+		assertEquals("75.0152W 9.19S", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 3);
+		assertEquals("127.7669E 35.9078N", t.getValue());
+		assertEquals(true, t.getIsNormalised());
 	}
 	
 	@Test

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDMSRegexTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDMSRegexTest.java
@@ -42,16 +42,6 @@ public class LatLonDMSRegexTest extends AbstractAnnotatorTest{
 	}
 	
 	@Test
-	public void testNegatives() throws Exception{
-	
-		jCas.setDocumentText("London is located in the UK, at -51°30'26\"S -0°7'39\"E. The following coordinates aren't valid: 12\234'56\"N; 12\"34'N 12\"34'S.");
-		processJCas();
-		
-		assertAnnotations(1,  Coordinate.class, 
-				new TestCoordinate(0, "-51°30'26\"S -0°7'39\"E", DMS, TYPE_POINT_COORDINATES_0_1275_51_507222222222225));
-	}
-	
-	@Test
 	public void testSpaces() throws Exception{
 	
 		jCas.setDocumentText("London is located in the UK, at (51 30 26 N, 0 7 39 W). The following coordinates aren't valid: 12°34'56\"N; 12°34'N 12°34'S.");
@@ -151,6 +141,69 @@ public class LatLonDMSRegexTest extends AbstractAnnotatorTest{
 		jCas.setDocumentText("59° 39.947' N, 10° 36.708' E");
 		processJCas();
 		assertEquals(1, JCasUtil.select(jCas, Coordinate.class).size());
+		Coordinate t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals(false, t.getIsNormalised());
+	}
+	
+	@Test
+	public void testNormaliseDeg() throws Exception{
+	
+		jCas.setDocumentText("Warsaw is in Poland, at (52°14'04\"N 21°01'04\"E). Rio de Janeiro is in Brazil, at (22°54'04\"S 43°12'04\"W).");
+		processJCas("storeDecimalValue", true);
+
+		assertAnnotations(2,  Coordinate.class, 
+				new TestCoordinate(0, "52°14'04\"N 21°01'04\"E", DMS, TYPE_POINT_COORDINATES_21_017777777777777_52_23444444444444),
+				new TestCoordinate(1, "22°54'04\"S 43°12'04\"W", DMS, TYPE_POINT_COORDINATES_43_20111111111111_22_90111111111111)
+		);
+		Coordinate t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals("52.2344444 21.0177778", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 1);
+		assertEquals("-22.9011111 -43.2011111", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+
+		jCas.reset();
+		jCas.setDocumentText("Warsaw is in Poland, at (52°14'04\"N 21°01'04\"E). Rio de Janeiro is in Brazil, at (22°54'04\"S 43°12'04\"W).");
+		processJCas("storeDecimalValue", true, "storeCardinalPoint", true);
+		assertAnnotations(2,  Coordinate.class, 
+				new TestCoordinate(0, "52°14'04\"N 21°01'04\"E", DMS, TYPE_POINT_COORDINATES_21_017777777777777_52_23444444444444),
+				new TestCoordinate(1, "22°54'04\"S 43°12'04\"W", DMS, TYPE_POINT_COORDINATES_43_20111111111111_22_90111111111111)
+		);
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals("52.2344444N 21.0177778E", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 1);
+		assertEquals("22.9011111S 43.2011111W", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+
+		jCas.reset();
+		jCas.setDocumentText("Warsaw is in Poland, at (52°14'04\"N 21°01'04\"E). Rio de Janeiro is in Brazil, at (22°54'04\"S 43°12'04\"W).");
+		processJCas("storeDecimalValue", true, "storeLongitudeFirst", true);
+
+		assertAnnotations(2,  Coordinate.class, 
+				new TestCoordinate(0, "52°14'04\"N 21°01'04\"E", DMS, TYPE_POINT_COORDINATES_21_017777777777777_52_23444444444444),
+				new TestCoordinate(1, "22°54'04\"S 43°12'04\"W", DMS, TYPE_POINT_COORDINATES_43_20111111111111_22_90111111111111)
+		);
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals("21.0177778 52.2344444", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 1);
+		assertEquals("-43.2011111 -22.9011111", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+
+		jCas.reset();
+		jCas.setDocumentText("Warsaw is in Poland, at (52°14'04\"N 21°01'04\"E). Rio de Janeiro is in Brazil, at (22°54'04\"S 43°12'04\"W).");
+		processJCas("storeDecimalValue", true, "storeCardinalPoint", true, "storeLongitudeFirst", true);
+		assertAnnotations(2,  Coordinate.class, 
+				new TestCoordinate(0, "52°14'04\"N 21°01'04\"E", DMS, TYPE_POINT_COORDINATES_21_017777777777777_52_23444444444444),
+				new TestCoordinate(1, "22°54'04\"S 43°12'04\"W", DMS, TYPE_POINT_COORDINATES_43_20111111111111_22_90111111111111)
+		);
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 0);
+		assertEquals("21.0177778E 52.2344444N", t.getValue());
+		assertEquals(true, t.getIsNormalised());
+		t = JCasUtil.selectByIndex(jCas, Coordinate.class, 1);
+		assertEquals("43.2011111W 22.9011111S", t.getValue());
+		assertEquals(true, t.getIsNormalised());
 	}
 	
 	@Test

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDMSRegexTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDMSRegexTest.java
@@ -42,6 +42,16 @@ public class LatLonDMSRegexTest extends AbstractAnnotatorTest{
 	}
 	
 	@Test
+	public void testNegatives() throws Exception{
+	
+		jCas.setDocumentText("London is located in the UK, at -51°30'26\"S -0°7'39\"E. The following coordinates aren't valid: 12\234'56\"N; 12\"34'N 12\"34'S.");
+		processJCas();
+		
+		assertAnnotations(1,  Coordinate.class, 
+				new TestCoordinate(0, "-51°30'26\"S -0°7'39\"E", DMS, TYPE_POINT_COORDINATES_0_1275_51_507222222222225));
+	}
+	
+	@Test
 	public void testSpaces() throws Exception{
 	
 		jCas.setDocumentText("London is located in the UK, at (51 30 26 N, 0 7 39 W). The following coordinates aren't valid: 12°34'56\"N; 12°34'N 12°34'S.");

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeDatesTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeDatesTest.java
@@ -1,0 +1,274 @@
+package uk.gov.dstl.baleen.annotators.cleaners;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.fit.factory.AnalysisEngineFactory;
+import org.apache.uima.fit.util.JCasUtil;
+import org.junit.Test;
+
+import uk.gov.dstl.baleen.annotators.testing.Annotations;
+import uk.gov.dstl.baleen.annotators.testing.AnnotatorTestBase;
+import uk.gov.dstl.baleen.types.semantic.Entity;
+import uk.gov.dstl.baleen.types.temporal.DateType;
+
+public class NormalizeDatesTest extends AnnotatorTestBase {
+	private static final String CORRECT_DATE = "1995-03-01";
+	private static final String PREFIX_STRING = "This occurred on ";
+	private static final int P_LENGTH = PREFIX_STRING.length();
+	
+	@Test
+	public void testConfiguration() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class, NormalizeDates.PARAM_DATE_FORMAT, "yy'/'MM'/'dd");
+		
+		String entityValue = "1 March 1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals("95/03/01", JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testTwoDigitYear() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1 March 95";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(entityValue, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(false, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testDaySuffix() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1st March 1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testLeadingDayName() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "Monday 1 March 1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testMultipleSpaces() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1   March  1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testLeadingZero() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "01 March 1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testAmericanOrder1() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "March 1 1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testMixedTest1() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "March 01st   1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testPointDelimiter() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1.3.1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testSlashDelimiter() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1/3/1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testHyphenDelimiter() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1-3-1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testLeadingZeroes() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "01-03-1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testISO8601Format() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1995-3-1";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testAmericanOrder2() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "3-23-1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals("1995-03-23", JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test2DigitYear() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1-3-95";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(entityValue, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(false, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testMixedTests2() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "Tues 1.03/1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createDateType(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals(CORRECT_DATE, JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, DateType.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testWrongEntity() throws Exception{
+		AnalysisEngine ndAE = AnalysisEngineFactory.createEngine(NormalizeDates.class);
+		
+		String entityValue = "1st March 1995";
+		
+		jCas.setDocumentText(PREFIX_STRING + entityValue);
+		Annotations.createEntity(jCas, P_LENGTH, P_LENGTH + entityValue.length(), entityValue);
+		ndAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Entity.class).size());
+		assertEquals(entityValue, JCasUtil.selectByIndex(jCas, Entity.class, 0).getValue());
+		assertEquals(false, JCasUtil.selectByIndex(jCas, Entity.class, 0).getIsNormalised());
+	}
+}

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeOSGBTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeOSGBTest.java
@@ -1,0 +1,71 @@
+package uk.gov.dstl.baleen.annotators.cleaners;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.fit.factory.AnalysisEngineFactory;
+import org.apache.uima.fit.util.JCasUtil;
+import org.junit.Test;
+
+import uk.gov.dstl.baleen.annotators.testing.AnnotatorTestBase;
+import uk.gov.dstl.baleen.types.geo.Coordinate;
+
+/**
+ * @author Christopher McLean
+ */
+public class NormalizeOSGBTest extends AnnotatorTestBase {
+	
+	private static final String CORRECT_FORMAT = "TQ299804";
+	private static final String PREFIX = "Trafalgar Square is at ";
+	private static final String SUB_TYPE = "osgb";
+
+	@Test
+	public void testSpaces() throws Exception {
+		AnalysisEngine ncAE = AnalysisEngineFactory.createEngine(NormalizeOSGB.class);
+		
+		String coordinateValue = "TQ 299 804";
+		createAndAddCoordinateEntity(coordinateValue, SUB_TYPE);
+		ncAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Coordinate.class).size());
+		assertEquals(CORRECT_FORMAT, JCasUtil.selectByIndex(jCas, Coordinate.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Coordinate.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testLowercase() throws Exception {
+		AnalysisEngine ncAE = AnalysisEngineFactory.createEngine(NormalizeOSGB.class);
+		
+		String coordinateValue = "tq299804";
+		createAndAddCoordinateEntity(coordinateValue, SUB_TYPE);
+		ncAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Coordinate.class).size());
+		assertEquals(CORRECT_FORMAT, JCasUtil.selectByIndex(jCas, Coordinate.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Coordinate.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testWrongSubType() throws Exception {
+		AnalysisEngine ncAE = AnalysisEngineFactory.createEngine(NormalizeOSGB.class);
+		
+		String coordinateValue = "tq299804";
+		createAndAddCoordinateEntity(coordinateValue, "dms");
+		ncAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Coordinate.class).size());
+		assertEquals("tq299804", JCasUtil.selectByIndex(jCas, Coordinate.class, 0).getValue());
+		assertEquals(false, JCasUtil.selectByIndex(jCas, Coordinate.class, 0).getIsNormalised());
+	}
+	
+	private void createAndAddCoordinateEntity(String entityValue, String subType) {
+		jCas.setDocumentText(PREFIX + entityValue);
+		Coordinate tel = new Coordinate(jCas);
+		tel.setSubType(subType);
+		tel.setValue(entityValue);
+		tel.setBegin(PREFIX.length());
+		tel.setEnd(PREFIX.length() + entityValue.length());
+		tel.addToIndexes();
+	}
+
+}

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeTimesTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeTimesTest.java
@@ -1,0 +1,306 @@
+package uk.gov.dstl.baleen.annotators.cleaners;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.fit.factory.AnalysisEngineFactory;
+import org.apache.uima.fit.util.JCasUtil;
+import org.junit.Test;
+
+import uk.gov.dstl.baleen.annotators.testing.AnnotatorTestBase;
+import uk.gov.dstl.baleen.types.temporal.Time;
+
+public class NormalizeTimesTest extends AnnotatorTestBase {
+	private static final String PREFIX = "The event occurred at ";
+	private static final int P_LENGTH = PREFIX.length();
+	
+	@Test
+	public void testNoon() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "12 Noon";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("12:00", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testMidDay() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "MidDay";
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("12:00", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test12HourNoAMPM() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "09:31";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("09:31", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(false, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test12HourDotSeparator() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "08.51";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("08:51", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test12Hour() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "7:15 am";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("07:15", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test12HourPM() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "8:00 pm";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("20:00", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	
+	@Test
+	public void test12HourAM() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "18:00 am";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("18:00", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test12HourTimeZone() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "17:00 EET pm";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("17:00 EET", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test12HourOffset() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "10:00 est+2 pm";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("22:00 EST+2", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test12HourMix() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "1:00 Gmt -08 Am";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("01:00 GMT-8", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testSimple() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "10am";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("10:00", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void testSimplePM() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "8pm";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("20:00", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	
+	@Test
+	public void testSimpleCase() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "1Pm";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("13:00", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test24Hour() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "2400 gmt";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("00:00 GMT", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test24HourTimeZone() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "2300 GMT+08";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("23:00 GMT+8", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test24HourTSpacing() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "0031 EET - 10";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("00:31 EET-10", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test24HourCase() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "2150est +09";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("21:50 EST+9", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test24HourZeroOffset() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "0000 CAT +0";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("00:00 CAT", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test24HourHoursPrefix() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "0356 hours";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("03:56", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test24HourHPrefix() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "0356H";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("03:56", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	private void createAndAddTimeEntity(String entityValue) {
+		jCas.setDocumentText(PREFIX + entityValue);
+		Time time = new Time(jCas);
+		time.setValue(entityValue);
+		time.setBegin(P_LENGTH);
+		time.setEnd(P_LENGTH + entityValue.length());
+		time.addToIndexes();
+	}
+}

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeTimesTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeTimesTest.java
@@ -42,6 +42,19 @@ public class NormalizeTimesTest extends AnnotatorTestBase {
 	}
 	
 	@Test
+	public void testMidNight() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "Midnight";
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("00:00", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
 	public void test12HourNoAMPM() throws Exception {
 		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
 		
@@ -216,6 +229,20 @@ public class NormalizeTimesTest extends AnnotatorTestBase {
 		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
 		
 		String entityValue = "2300 GMT+08";
+		
+		createAndAddTimeEntity(entityValue);
+		ntAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Time.class).size());
+		assertEquals("23:00 GMT+8", JCasUtil.selectByIndex(jCas, Time.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Time.class, 0).getIsNormalised());
+	}
+	
+	@Test
+	public void test24HourSeparatorTimeZone() throws Exception {
+		AnalysisEngine ntAE = AnalysisEngineFactory.createEngine(NormalizeTimes.class);
+		
+		String entityValue = "23:00 GMT+08";
 		
 		createAndAddTimeEntity(entityValue);
 		ntAE.process(jCas);

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeWhitespaceTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeWhitespaceTest.java
@@ -31,6 +31,7 @@ public class NormalizeWhitespaceTest extends AnnotatorTestBase {
 		
 		assertEquals(1, JCasUtil.select(jCas, Person.class).size());
 		assertEquals(CORRECT_WHITESPACING, JCasUtil.selectByIndex(jCas, Person.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Person.class, 0).getIsNormalised());
 	}
 	
 	@Test
@@ -45,6 +46,7 @@ public class NormalizeWhitespaceTest extends AnnotatorTestBase {
 		
 		assertEquals(1, JCasUtil.select(jCas, Person.class).size());
 		assertEquals(CORRECT_WHITESPACING, JCasUtil.selectByIndex(jCas, Person.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Person.class, 0).getIsNormalised());
 	}
 	
 	@Test
@@ -58,6 +60,7 @@ public class NormalizeWhitespaceTest extends AnnotatorTestBase {
 		
 		assertEquals(1, JCasUtil.select(jCas, Person.class).size());
 		assertEquals(CORRECT_WHITESPACING, JCasUtil.selectByIndex(jCas, Person.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Person.class, 0).getIsNormalised());
 	}
 	
 	@Test
@@ -72,6 +75,7 @@ public class NormalizeWhitespaceTest extends AnnotatorTestBase {
 		
 		assertEquals(1, JCasUtil.select(jCas, Person.class).size());
 		assertEquals(CORRECT_WHITESPACING, JCasUtil.selectByIndex(jCas, Person.class, 0).getValue());
+		assertEquals(true, JCasUtil.selectByIndex(jCas, Person.class, 0).getIsNormalised());
 	}
 	
 	@Test
@@ -87,5 +91,6 @@ public class NormalizeWhitespaceTest extends AnnotatorTestBase {
 		
 		assertEquals(1, JCasUtil.select(jCas, Person.class).size());
 		assertEquals(null, JCasUtil.selectByIndex(jCas, Person.class, 0).getValue());
+		assertEquals(false, JCasUtil.selectByIndex(jCas, Person.class, 0).getIsNormalised());
 	}
 }

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchTest.java
@@ -121,7 +121,7 @@ public class ElasticsearchTest extends ElasticsearchConsumerTestBase{
 		assertEquals(4, entities.size());
 
 		Map<String, Object> person = entities.get(0);
-		assertEquals(8, person.size());
+		assertEquals(9, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -130,7 +130,7 @@ public class ElasticsearchTest extends ElasticsearchConsumerTestBase{
 		assertNotNull(person.get(EXTERNAL_ID));
 
 		Map<String, Object> location = entities.get(1);
-		assertEquals(8, location.size());
+		assertEquals(9, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -145,7 +145,7 @@ public class ElasticsearchTest extends ElasticsearchConsumerTestBase{
 		assertEquals(geometryMap, location.get("geoJson"));
 
 		Map<String, Object> date = entities.get(2);
-		assertEquals(7, date.size());
+		assertEquals(8, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));
@@ -154,7 +154,7 @@ public class ElasticsearchTest extends ElasticsearchConsumerTestBase{
 		assertNotNull(date.get(EXTERNAL_ID));
 
 		Map<String, Object> email = entities.get(3);
-		assertEquals(7, email.size());
+		assertEquals(8, email.size());
 		assertEquals(66, email.get(BEGIN));
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyElasticsearchTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyElasticsearchTest.java
@@ -126,7 +126,7 @@ public class LegacyElasticsearchTest extends ElasticsearchConsumerTestBase {
 		assertEquals(4, entities.size());
 
 		Map<String, Object> person = entities.get(0);
-		assertEquals(8, person.size());
+		assertEquals(9, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -135,7 +135,7 @@ public class LegacyElasticsearchTest extends ElasticsearchConsumerTestBase {
 		assertNotNull(person.get(UNIQUE_ID));
 
 		Map<String, Object> location = entities.get(1);
-		assertEquals(8, location.size());
+		assertEquals(9, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -153,7 +153,7 @@ public class LegacyElasticsearchTest extends ElasticsearchConsumerTestBase {
 		assertEquals(geoJsonMap, location.get("geoJson"));
 
 		Map<String, Object> date = entities.get(2);
-		assertEquals(7, date.size());
+		assertEquals(8, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));
@@ -162,7 +162,7 @@ public class LegacyElasticsearchTest extends ElasticsearchConsumerTestBase {
 		assertNotNull(date.get(UNIQUE_ID));
 
 		Map<String, Object> email = entities.get(3);
-		assertEquals(7, email.size());
+		assertEquals(8, email.size());
 		assertEquals(66, email.get(BEGIN));
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
@@ -259,7 +259,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals(4, entities.size());
 
 		Map<String, Object> person = (Map<String, Object>)entities.get(0);
-		assertEquals(9, person.size());
+		assertEquals(10, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -267,7 +267,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals("James", person.get(VALUE));
 
 		Map<String, Object> location =(Map<String, Object>) entities.get(1);
-		assertEquals(9, location.size());
+		assertEquals(10, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -279,7 +279,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertArrayEquals(new Double[] { -0.1, 51.5 }, ((BasicDBList)((DBObject)((DBObject)location.get(GEO_JSON)).get("geometry")).get("coordinates")).toArray());
 
 		Map<String, Object> date = (Map<String, Object>)entities.get(2);
-		assertEquals(8, date.size());
+		assertEquals(9, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));
@@ -287,7 +287,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals("19th February 2015", date.get(VALUE));
 
 		Map<String, Object> email = (Map<String, Object>) entities.get(3);
-		assertEquals(8, email.size());
+		assertEquals(9, email.size());
 		assertEquals(66, email.get(BEGIN));
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.cas.Feature;
 import org.apache.uima.fit.factory.AnalysisEngineFactory;
 import org.apache.uima.fit.factory.ExternalResourceFactory;
 import org.apache.uima.jcas.tcas.DocumentAnnotation;
@@ -228,6 +229,10 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		p.setEnd(5);
 		p.setValue("James");
 		p.addToIndexes();
+		// Obtain the number of features in the object. These should all
+		// be stored in the database so the count retrieved from the
+		// database should match.
+		int expectedPersonSize =  p.getType().getFeatures().size();
 
 		Location l = new Location(jCas);
 		l.setBegin(14);
@@ -235,6 +240,10 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		l.setValue("London");
 		l.setGeoJson("{\"type\": \"Point\", \"coordinates\": [-0.1, 51.5]}");
 		l.addToIndexes();
+		// Obtain the number of features in the object. These should all
+		// be stored in the database so the count retrieved from the
+		// database should match.
+		int expectedLocationSize =  l.getType().getFeatures().size();
 
 		DateType d = new DateType(jCas);
 		d.setBegin(24);
@@ -242,6 +251,10 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		d.setConfidence(1.0);
 		d.setValue("19th February 2015");
 		d.addToIndexes();
+		// Obtain the number of features in the object. These should all
+		// be stored in the database so the count retrieved from the
+		// database should match.
+		int expectedDateSize =  d.getType().getFeatures().size();
 
 		CommsIdentifier ci = new CommsIdentifier(jCas);
 		ci.setBegin(66);
@@ -249,6 +262,10 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		ci.setSubType("email");
 		ci.setValue("james@example.com");
 		ci.addToIndexes();
+		// Obtain the number of features in the object. These should all
+		// be stored in the database so the count retrieved from the
+		// database should match.
+		int expectedEmailSize =  ci.getType().getFeatures().size();
 
 		ae.process(jCas);
 
@@ -259,7 +276,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals(4, entities.size());
 
 		Map<String, Object> person = (Map<String, Object>)entities.get(0);
-		assertEquals(10, person.size());
+		assertEquals(expectedPersonSize, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -267,7 +284,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals("James", person.get(VALUE));
 
 		Map<String, Object> location =(Map<String, Object>) entities.get(1);
-		assertEquals(10, location.size());
+		assertEquals(expectedLocationSize, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -279,7 +296,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertArrayEquals(new Double[] { -0.1, 51.5 }, ((BasicDBList)((DBObject)((DBObject)location.get(GEO_JSON)).get("geometry")).get("coordinates")).toArray());
 
 		Map<String, Object> date = (Map<String, Object>)entities.get(2);
-		assertEquals(9, date.size());
+		assertEquals(expectedDateSize, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));
@@ -287,7 +304,7 @@ public class LegacyMongoTest extends ConsumerTestBase {
 		assertEquals("19th February 2015", date.get(VALUE));
 
 		Map<String, Object> email = (Map<String, Object>) entities.get(3);
-		assertEquals(9, email.size());
+		assertEquals(expectedEmailSize, email.size());
 		assertEquals(66, email.get(BEGIN));
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));

--- a/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/MongoTest.java
+++ b/baleen/baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/MongoTest.java
@@ -279,7 +279,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> a = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, PERSON));
 		Map<String, Object> person = ((List<Map<String, Object>>)a.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(9, person.size());
+		assertEquals(10, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -288,7 +288,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> b = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, LONDON));
 		Map<String, Object> location = ((List<Map<String, Object>>)b.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(9, location.size());
+		assertEquals(10, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -300,7 +300,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> c = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, DATE));
 		Map<String, Object> date = ((List<Map<String, Object>>)c.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(8, date.size());
+		assertEquals(9, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));
@@ -309,7 +309,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> d = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, EMAIL));
 		Map<String, Object> email = ((List<Map<String, Object>>)d.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(8, email.size());
+		assertEquals(9, email.size());
 		assertEquals(66, email.get(BEGIN));
 		assertEquals(83, email.get(END));
 		assertEquals(0.0, email.get(CONFIDENCE));
@@ -319,7 +319,7 @@ public class MongoTest extends ConsumerTestBase {
 		
 		Map<String, Object> e = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, WENT));
 		Map<String, Object> went = ((List<Map<String, Object>>)e.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(9, went.size());
+		assertEquals(10, went.size());
 		assertEquals(6, went.get(BEGIN));
 		assertEquals(10, went.get(END));
 		assertEquals(0.0, went.get(CONFIDENCE));
@@ -446,7 +446,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> a = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, PERSON));
 		Map<String, Object> person = ((List<Map<String, Object>>)a.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(9, person.size());
+		assertEquals(10, person.size());
 		assertEquals(0, person.get(BEGIN));
 		assertEquals(5, person.get(END));
 		assertEquals(0.0, person.get(CONFIDENCE));
@@ -455,7 +455,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> b = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, LONDON));
 		Map<String, Object> location = ((List<Map<String, Object>>)b.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(9, location.size());
+		assertEquals(10, location.size());
 		assertEquals(14, location.get(BEGIN));
 		assertEquals(20, location.get(END));
 		assertEquals(0.0, location.get(CONFIDENCE));
@@ -467,7 +467,7 @@ public class MongoTest extends ConsumerTestBase {
 
 		Map<String, Object> c = (Map<String, Object>)entities.findOne(new BasicDBObject(Mongo.FIELD_ENTITIES + "." + VALUE, DATE));
 		Map<String, Object> date = ((List<Map<String, Object>>)c.get(Mongo.FIELD_ENTITIES)).get(0);
-		assertEquals(8, date.size());
+		assertEquals(9, date.size());
 		assertEquals(24, date.get(BEGIN));
 		assertEquals(42, date.get(END));
 		assertEquals(1.0, date.get(CONFIDENCE));

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity.java
@@ -13,8 +13,8 @@ import uk.gov.dstl.baleen.types.Base;
 
 
 /** Type to represent named entities - values that are assigned a semantic type.
- * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
- * XML source: C:/co/git/CCD-DE/RMR/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+ * Updated by JCasGen Wed Apr 06 16:49:30 BST 2016
+ * XML source: /home/baleen/provide-normalize-cleaners/baleen/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
  * @generated */
 public class Entity extends Base implements Recordable {
   @SuppressWarnings ("hiding")
@@ -115,6 +115,28 @@ public class Entity extends Base implements Recordable {
     if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_referent == null)
       jcasType.jcas.throwFeatMissing("referent", "uk.gov.dstl.baleen.types.semantic.Entity");
     jcasType.ll_cas.ll_setRefValue(addr, ((Entity_Type)jcasType).casFeatCode_referent, jcasType.ll_cas.ll_getFSRef(v));}    
+   
+    
+  //*--------------*
+  //* Feature: isNormalised
+
+  /** getter for isNormalised - gets Marks the entity value as having been normalised from the original value
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getIsNormalised() {
+    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_isNormalised == null)
+      jcasType.jcas.throwFeatMissing("isNormalised", "uk.gov.dstl.baleen.types.semantic.Entity");
+    return jcasType.ll_cas.ll_getBooleanValue(addr, ((Entity_Type)jcasType).casFeatCode_isNormalised);}
+    
+  /** setter for isNormalised - sets Marks the entity value as having been normalised from the original value 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setIsNormalised(boolean v) {
+    if (Entity_Type.featOkTst && ((Entity_Type)jcasType).casFeat_isNormalised == null)
+      jcasType.jcas.throwFeatMissing("isNormalised", "uk.gov.dstl.baleen.types.semantic.Entity");
+    jcasType.ll_cas.ll_setBooleanValue(addr, ((Entity_Type)jcasType).casFeatCode_isNormalised, v);}    
    
     
   //*--------------*

--- a/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity_Type.java
+++ b/baleen/baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity_Type.java
@@ -15,7 +15,7 @@ import org.apache.uima.cas.Feature;
 import uk.gov.dstl.baleen.types.Base_Type;
 
 /** Type to represent named entities - values that are assigned a semantic type.
- * Updated by JCasGen Fri Feb 05 14:54:30 GMT 2016
+ * Updated by JCasGen Wed Apr 06 16:49:30 BST 2016
  * @generated */
 public class Entity_Type extends Base_Type {
   /** @generated 
@@ -96,6 +96,30 @@ public class Entity_Type extends Base_Type {
   
  
   /** @generated */
+  final Feature casFeat_isNormalised;
+  /** @generated */
+  final int     casFeatCode_isNormalised;
+  /** @generated
+   * @param addr low level Feature Structure reference
+   * @return the feature value 
+   */ 
+  public boolean getIsNormalised(int addr) {
+        if (featOkTst && casFeat_isNormalised == null)
+      jcas.throwFeatMissing("isNormalised", "uk.gov.dstl.baleen.types.semantic.Entity");
+    return ll_cas.ll_getBooleanValue(addr, casFeatCode_isNormalised);
+  }
+  /** @generated
+   * @param addr low level Feature Structure reference
+   * @param v value to set 
+   */    
+  public void setIsNormalised(int addr, boolean v) {
+        if (featOkTst && casFeat_isNormalised == null)
+      jcas.throwFeatMissing("isNormalised", "uk.gov.dstl.baleen.types.semantic.Entity");
+    ll_cas.ll_setBooleanValue(addr, casFeatCode_isNormalised, v);}
+    
+  
+ 
+  /** @generated */
   final Feature casFeat_subType;
   /** @generated */
   final int     casFeatCode_subType;
@@ -137,6 +161,10 @@ public class Entity_Type extends Base_Type {
  
     casFeat_referent = jcas.getRequiredFeatureDE(casType, "referent", "uk.gov.dstl.baleen.types.semantic.ReferenceTarget", featOkTst);
     casFeatCode_referent  = (null == casFeat_referent) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_referent).getCode();
+
+ 
+    casFeat_isNormalised = jcas.getRequiredFeatureDE(casType, "isNormalised", "uima.cas.Boolean", featOkTst);
+    casFeatCode_isNormalised  = (null == casFeat_isNormalised) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_isNormalised).getCode();
 
  
     casFeat_subType = jcas.getRequiredFeatureDE(casType, "subType", "uima.cas.String", featOkTst);

--- a/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
+++ b/baleen/baleen-uima/src/main/resources/types/semantic_type_system.xml
@@ -26,6 +26,11 @@ This XML file classified as UK OFFICIAL.</description>
           <rangeTypeName>uk.gov.dstl.baleen.types.semantic.ReferenceTarget</rangeTypeName>
         </featureDescription>
         <featureDescription>
+          <name>isNormalised</name>
+          <description>Marks the entity value as having been normalised from the original value</description>
+          <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
           <name>subType</name>
           <description>String identifying sub type of entity.</description>
           <rangeTypeName>uima.cas.String</rangeTypeName>

--- a/baleen/baleen-uima/src/test/java/uk/gov/dstl/baleen/types/BaleenAnnotationTest.java
+++ b/baleen/baleen-uima/src/test/java/uk/gov/dstl/baleen/types/BaleenAnnotationTest.java
@@ -11,7 +11,7 @@ import uk.gov.dstl.baleen.core.utils.IdentityUtils;
 import uk.gov.dstl.baleen.types.common.CommsIdentifier;
 
 public class BaleenAnnotationTest {
-	private static final String HASH_TWO = "b7d96a702c8748492a98fc28198b5796490bbc728ac9b623c99ade4dcda131f0";
+	private static final String HASH_TWO = "42e8536751651b04ca051139437c55b0ec26f3a9810014b7e7993c1dc3775aff";
 	private static final String HASH_ONE = "304159f11fd4e939839e2b4e114b03539d16f9a64278cfffc93143d328931de6";
 
 	@Test


### PR DESCRIPTION
This change request adds new cleaners and modifies existing cleaners and annotators to provide the capability to normalize certain types of annotation data. It includes the addition of an isNormalized flag in the Entity type to enable cleaners and annotators to record when data has been modified to meet a specific normalized format. This enables annotators, cleaners, and consumers further down the pipeline to decide whether to use normalized data or refer back to the original text in the document.

A summary of the file additions / changes is as follows:

### Addition of isNormalised field
baleen-uima/src/main/resources/types/semantic_type_system.xml
baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity_Type.java
baleen-uima/src/main/java/uk/gov/dstl/baleen/types/semantic/Entity.java
baleen-uima/src/test/java/uk/gov/dstl/baleen/types/BaleenAnnotationTest.java
baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/MongoTest.java
baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyMongoTest.java
baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/LegacyElasticsearchTest.java
baleen-consumers/src/test/java/uk/gov/dstl/baleen/consumers/ElasticsearchTest.java

### New Normalization Cleaners
baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/helpers/AbstractNormalizeEntities.java
baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeDates.java
baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeOSGB.java
baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeTimes.java
baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeDatesTest.java
baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeOSGBTest.java
baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeTimesTest.java


### Modified Cleaners and Annotators to support normalization changes
baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeWhitespace.java
- Refactored to extend from the new AbstractNormalizeEntities class

baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/regex/LatLon.java
- Added additional regular expressions to support extra decimal degree formats
- Added resources and associated functionality to allow normalization of coordinate text stored in the value field.

baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDDRegexTest.java
baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/LatLonDMSRegexTest.java
baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/NormalizeWhitespaceTest.java
