### PR TITLE
Addition of cleaner to remove all whitespace

### DIFF
--- a/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/RemoveWhitespace.java
+++ b/baleen/baleen-annotators/src/main/java/uk/gov/dstl/baleen/annotators/cleaners/RemoveWhitespace.java
@@ -1,0 +1,91 @@
+package uk.gov.dstl.baleen.annotators.cleaners;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.uima.UimaContext;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+
+import uk.gov.dstl.baleen.annotators.cleaners.helpers.AbstractNormalizeEntities;
+import uk.gov.dstl.baleen.types.semantic.Entity;
+
+import com.google.common.base.Strings;
+
+/**
+ * This cleaner removes whitespace in the values of entities matching the selected entity types.
+ * <p>The entity types to process are specified in the pipeline configuration file using the
+ * entityList configuration parameter.</p>
+ * 
+ * <p>The entityList allows specification of entity sub-type values or entity type values, with
+ * sub-type taking precedence over type.</p>
+ * 
+ * <p>Removing whitespace is considered a normalisation operation so the normalised flag
+ * will be set if any change is made to the entity value string</p>
+ * 
+ * <p>This cleaner is best used towards the end of the pipeline as it removes whitespace
+ * which may be  being used as a delimiter by other cleaners e.g. the cleaner to normalise
+ * dates will recognise and format "1 3 1995" but "131995" (the result after using this
+ * cleaner) will be left unchanged by the date normalisation.</p>
+ * @baleen.javadoc
+ * 
+ */
+public class RemoveWhitespace extends AbstractNormalizeEntities {
+	/**
+	 * A list of the entity sub-types and type which are to have their whitespace removed.
+	 * <p>The strings specified are compared against an entities sub-type value first and
+	 * then the entities type value if no match is found. This allows fine control over
+	 * selection of entities to process. e.g. specifying telephone will result in
+	 * only CommsIdentifier entities with a sub-type of telephone being processed, those
+	 * with a sub-type of ipv4address will be left untouched. However, specifying CommsIdentifier
+	 * will result all entities of that type being processed whatever their sub-type is.</p> 
+	 * <p>Default value is used to prevent execution in case a blank list is supplied.</p>
+	 * @baleen.config entityList
+	 */
+	public static final String PARAM_ENTITY_LIST = "entityList";
+	private static final String DEFAULT_VALUE = "NoEntities";
+	@ConfigurationParameter(name = PARAM_ENTITY_LIST, defaultValue={DEFAULT_VALUE})
+	String[] entityList;
+	
+	/**
+	 * Convert entityList into a set, to speedup lookups
+	 */
+	Set<String> entityTypes;
+
+	@Override
+	public void doInitialize(UimaContext aContext)
+			throws ResourceInitializationException {
+		super.doInitialize(aContext);
+
+		if (!entityList[0].equals(DEFAULT_VALUE)) {
+			entityTypes = new HashSet<String>();
+			entityTypes.addAll(Arrays.asList(entityList));
+		}
+	}
+
+	@Override
+	protected boolean shouldNormalize(Entity e) {
+		Boolean removeWhitespace = false;
+		
+		if (null != entityTypes) {
+			String entityType = e.getSubType();
+			if (Strings.isNullOrEmpty(entityType)) {
+				entityType = e.getTypeName();
+				entityType = entityType.substring(entityType.lastIndexOf('.') + 1);
+			}
+
+			if (entityTypes.contains(entityType)) {
+				removeWhitespace = true;
+			}
+		}
+		return removeWhitespace;
+	}
+
+	@Override
+	protected String normalize(Entity e) {
+		String normalized=e.getValue().replaceAll("[\\s]", "");
+		return normalized;
+	}
+
+}

--- a/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/RemoveWhitespaceTest.java
+++ b/baleen/baleen-annotators/src/test/java/uk/gov/dstl/baleen/annotators/cleaners/RemoveWhitespaceTest.java
@@ -1,0 +1,121 @@
+package uk.gov.dstl.baleen.annotators.cleaners;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.fit.factory.AnalysisEngineFactory;
+import org.apache.uima.fit.util.JCasUtil;
+
+import uk.gov.dstl.baleen.annotators.testing.Annotations;
+import uk.gov.dstl.baleen.annotators.testing.AnnotatorTestBase;
+import uk.gov.dstl.baleen.types.common.CommsIdentifier;
+import uk.gov.dstl.baleen.types.common.Vehicle;
+import uk.gov.dstl.baleen.types.semantic.Entity;
+import uk.gov.dstl.baleen.types.temporal.DateType;
+
+public class RemoveWhitespaceTest extends AnnotatorTestBase {
+
+	private final static String SUFFIX = " is an entity.";
+	
+	@Test
+	public void testDefaultParameter() throws Exception {
+		AnalysisEngine nrwAE = AnalysisEngineFactory.createEngine(RemoveWhitespace.class);
+		
+		String entityValue = " 21 4 2015";
+		
+		jCas.setDocumentText(entityValue + SUFFIX);
+		Annotations.createEntity(jCas, 0, entityValue.length(), entityValue);
+		nrwAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Entity.class).size());
+		assertEquals(" 21 4 2015", JCasUtil.selectByIndex(jCas, Entity.class, 0).getValue());
+	}
+	
+	@Test
+	public void testSpaces() throws Exception {
+		AnalysisEngine nrwAE = AnalysisEngineFactory.createEngine(RemoveWhitespace.class, RemoveWhitespace.PARAM_ENTITY_LIST, new String[]{"DateType"});
+		
+		String entityValue = " 21 4 2015";
+		
+		jCas.setDocumentText(entityValue + SUFFIX);
+		Annotations.createDateType(jCas, 0, entityValue.length(), entityValue);
+		nrwAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals("2142015", JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+	}
+	
+	@Test
+	public void testTabs() throws Exception {
+		AnalysisEngine nrwAE = AnalysisEngineFactory.createEngine(RemoveWhitespace.class, RemoveWhitespace.PARAM_ENTITY_LIST, new String[]{"motorVehicle"});
+		
+		String entityValue = "RG1\t4AB";
+		
+		createAndAddVehicleEntity(entityValue);
+		nrwAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, Vehicle.class).size());
+		assertEquals("RG14AB", JCasUtil.selectByIndex(jCas, Vehicle.class, 0).getValue());
+	}
+	
+	@Test
+	public void testNewline() throws Exception {
+		AnalysisEngine nrwAE = AnalysisEngineFactory.createEngine(RemoveWhitespace.class, RemoveWhitespace.PARAM_ENTITY_LIST, new String[]{"telephone"});
+		
+		String entityValue = "+441234567890\n";
+		
+		createAndAddTelephoneEntity(entityValue);
+		nrwAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, CommsIdentifier.class).size());
+		assertEquals("+441234567890", JCasUtil.selectByIndex(jCas, CommsIdentifier.class, 0).getValue());
+	}
+	
+	@Test
+	public void testMixed() throws Exception {
+		AnalysisEngine nrwAE = AnalysisEngineFactory.createEngine(RemoveWhitespace.class, RemoveWhitespace.PARAM_ENTITY_LIST, new String[]{"DateType"});
+		
+		String entityValue = "Wed	21 3 15\n";
+		
+		jCas.setDocumentText(entityValue + SUFFIX);
+		Annotations.createDateType(jCas, 0, entityValue.length(), entityValue);
+		nrwAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, DateType.class).size());
+		assertEquals("Wed21315", JCasUtil.selectByIndex(jCas, DateType.class, 0).getValue());
+	}
+	
+	@Test
+	public void testWrongEntityType() throws Exception {
+		AnalysisEngine nrwAE = AnalysisEngineFactory.createEngine(RemoveWhitespace.class, RemoveWhitespace.PARAM_ENTITY_LIST, new String[]{"DateType"});
+		
+		String entityValue = "+44 1234 567890";
+		
+		createAndAddTelephoneEntity(entityValue);
+		nrwAE.process(jCas);
+		
+		assertEquals(1, JCasUtil.select(jCas, CommsIdentifier.class).size());
+		assertEquals("+44 1234 567890", JCasUtil.selectByIndex(jCas, CommsIdentifier.class, 0).getValue());
+	}
+	
+	private void createAndAddTelephoneEntity(String entityValue) {
+		jCas.setDocumentText(entityValue + SUFFIX);
+		CommsIdentifier tel = new CommsIdentifier(jCas);
+		tel.setSubType("telephone");
+		tel.setValue(entityValue);
+		tel.setBegin(0);
+		tel.setEnd(entityValue.length());
+		tel.addToIndexes();
+	}
+	
+	private void createAndAddVehicleEntity(String entityValue) {
+		jCas.setDocumentText(entityValue + SUFFIX);
+		Vehicle motor = new Vehicle(jCas);
+		motor.setSubType("motorVehicle");
+		motor.setValue(entityValue);
+		motor.setBegin(0);
+		motor.setEnd(entityValue.length());
+		motor.addToIndexes();
+	}
+}


### PR DESCRIPTION
This cleaner removes whitespace in the values of entities matching the selected entity types. (This is different to the NormalizeWhitespace cleaner which replaces instances of whitespace with  a single space and operates on all entities.)

The entity types to process are specified in the pipeline configuration file using the associated configuration parameter. They relate to the values stored in the sub-type and type fields of an entity and allow cleaning to be fine tuned to a specific sub-type of an entity type if required. The cleaning is seen as a form of normalisation so the the entities normalised flag is set if its value is changed.