### PR TITLE
Add fix for folders being added to a watched folder

### DIFF
--- a/baleen/baleen-collectionreaders/src/main/java/uk/gov/dstl/baleen/collectionreaders/FolderReader.java
+++ b/baleen/baleen-collectionreaders/src/main/java/uk/gov/dstl/baleen/collectionreaders/FolderReader.java
@@ -272,7 +272,14 @@ public class FolderReader extends BaleenCollectionReader {
 				Path dir = watchKeys.get(key);
 				if(dir != null){
 					Path resolved = dir.resolve(pathEvent.context());
-					addFile(resolved);
+					if (resolved.toFile().isDirectory()) {
+                        if (recursive) {
+                            addFilesFromDir(resolved.toFile());
+                            registerDirectory(resolved);
+                        }
+                    } else {
+                        addFile(resolved);
+                    }
 				}else{
 					getMonitor().warn("WatchKey not found - file '{}' will not be added to the queue", pathEvent.context());
 				}

--- a/baleen/baleen-collectionreaders/src/test/java/uk/gov/dstl/baleen/collectionreaders/FolderReaderTest.java
+++ b/baleen/baleen-collectionreaders/src/test/java/uk/gov/dstl/baleen/collectionreaders/FolderReaderTest.java
@@ -305,6 +305,71 @@ public class FolderReaderTest {
 		bcr.close();
 	}
 	
+    @Test
+    public void testCreateDirectoryNotProcessed() throws Exception {
+        BaleenCollectionReader bcr = (BaleenCollectionReader) CollectionReaderFactory.createReader(FolderReader.class,
+                FolderReader.PARAM_FOLDERS, new String[] { inputDir.getPath() });
+
+        assertFalse(bcr.doHasNext());
+
+        File folder = new File(inputDir, DIR);
+        folder.mkdir();
+        Thread.sleep(TIMEOUT);
+
+        assertFalse(bcr.doHasNext());
+
+        folder.delete();
+    }
+
+    @Test
+    public void testCreateDirectoryIsWatched() throws Exception {
+        BaleenCollectionReader bcr = (BaleenCollectionReader) CollectionReaderFactory.createReader(FolderReader.class,
+                FolderReader.PARAM_FOLDERS, new String[] { inputDir.getPath() });
+
+        assertFalse(bcr.doHasNext());
+
+        File folder = new File(inputDir, DIR);
+        folder.mkdir();
+        Thread.sleep(TIMEOUT);
+
+        assertFalse(bcr.doHasNext());
+
+        File f11 = new File(folder, TEXT1_FILE);
+        f11.createNewFile();
+
+        Thread.sleep(TIMEOUT);
+
+        assertNextSourceNotNull(bcr);
+
+        f11.delete();
+        folder.delete();
+    }
+
+    @Test
+    public void testCreateDirectoryIsNotWatchedIfNotRecursive() throws Exception {
+        BaleenCollectionReader bcr = (BaleenCollectionReader) CollectionReaderFactory.createReader(FolderReader.class,
+                FolderReader.PARAM_RECURSIVE, false,
+                FolderReader.PARAM_FOLDERS, new String[] { inputDir.getPath() });
+
+        assertFalse(bcr.doHasNext());
+
+        File folder = new File(inputDir, DIR);
+        folder.mkdir();
+        Thread.sleep(TIMEOUT);
+
+        assertFalse(bcr.doHasNext());
+
+        File f11 = new File(folder, TEXT1_FILE);
+        f11.createNewFile();
+
+        Thread.sleep(TIMEOUT);
+
+        assertFalse(bcr.doHasNext());
+
+        f11.delete();
+        folder.delete();
+    }
+
 	private void assertNextSourceNotNull(BaleenCollectionReader bcr) throws Exception{
 		assertTrue(bcr.doHasNext());
 		bcr.getNext(jCas.getCas());


### PR DESCRIPTION
In FolderReader, if a folder is added to a watched folder it is incorrectly
marked as a file.

Tests and a fix have been added to correct the behaviour.
If a folder is added then the folder is registered and watched, if recursive is set to true,
and otherwise it is ignored.
