### PR TITLE
Force the use of liblinear version 1.94

### DIFF
--- a/baleen-annotators/pom.xml
+++ b/baleen-annotators/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -34,6 +35,11 @@
       <groupId>org.apache.opennlp</groupId>
       <artifactId>opennlp-tools</artifactId>
       <version>${opennlp.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.bwaldvogel</groupId>
+      <artifactId>liblinear</artifactId>
+      <version>${liblinear.version}</version>
     </dependency>
     <dependency>
       <groupId>org.maltparser</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <jung.version>2.1.1</jung.version>
     <krill.version>1.0.3</krill.version>
     <languagedetector.version>0.6</languagedetector.version>
+    <liblinear.version>1.94</liblinear.version>
     <logback.version>1.2.3</logback.version>
     <maltparser.version>1.9.2</maltparser.version>
     <mboxiterator.version>0.8.1</mboxiterator.version>


### PR DESCRIPTION
This stops the close stream issue when using OdinParser.
It remains possible that this introduces issue for the maltparser.
In particular, it is lileky to leave a model file reader unclosed,
due to the change in behaviour between the two versions, though
it's not clear that this particular code path is used in Baleen.

We do know that all the test pass and manual testing has not produced an issue.

Fixes #80