### PR TITLE
Extend the YAML include functionality

### DIFF
--- a/baleen-core/src/main/java/uk/gov/dstl/baleen/core/utils/yaml/IncludedYaml.java
+++ b/baleen-core/src/main/java/uk/gov/dstl/baleen/core/utils/yaml/IncludedYaml.java
@@ -72,10 +72,15 @@ public class IncludedYaml extends AbstractBaseYaml implements Yaml {
       Object value = e.getValue();
       if (INCLUDE.equals(key)) {
         if (value instanceof String) {
-          return mapping.apply((String) value).dataTree();
+          Object includedTree = mapping.apply((String) value).dataTree();
+          if (includedTree instanceof Map) {
+            Map<String, Object> includedMap = (Map<String, Object>) includedTree;
+            includedMap.forEach((k, v) -> processed.put(k, v));
+          } else {
+            return includedTree;
+          }
         } else if (value instanceof List) {
           return getIncludedList((List<String>) value);
-
         } else {
           throw new IllegalArgumentException("include must be a string or list of strings");
         }

--- a/baleen-core/src/test/java/uk/gov/dstl/baleen/core/utils/yaml/IncludeYamlTest.java
+++ b/baleen-core/src/test/java/uk/gov/dstl/baleen/core/utils/yaml/IncludeYamlTest.java
@@ -22,6 +22,7 @@ public class IncludeYamlTest {
   private static final String YAMLCONFIGURATION_YAML = "yamlconfiguration.yaml";
   private static final String GRAND_PARENT_YAML = "grandparent.yaml";
   private static final String PARENT_YAML = "parent.yaml";
+  private static final String PARENT_INCLUDE_YAML = "parentInclude.yaml";
 
   Function<String, Yaml> mapping =
       new Function<String, Yaml>() {
@@ -54,6 +55,25 @@ public class IncludeYamlTest {
   public void simpleInclude() throws IOException {
     Yaml yaml = new IncludedYaml(new YamlFile(YamlFileTest.class, PARENT_YAML), mapping);
     String expected = getRaw(PARENT_YAML);
+    assertEquals(expected, yaml.original());
+    Object data = yaml.dataTree();
+    assertTrue(data instanceof Map);
+    Map<String, Object> dataTree = (Map<String, Object>) data;
+    assertTrue(dataTree.containsKey("collectionreader"));
+    List<Object> annotators = (List<Object>) dataTree.get("annotators");
+    assertEquals(2, annotators.size());
+    assertEquals(
+        "uk.gov.dstl.baleen.testing.DummyAnnotator",
+        ((Map<String, Object>) annotators.get(1)).get("class"));
+    assertEquals(
+        "uk.gov.dstl.baleen.testing.DummyResourceAnnotator",
+        ((Map<String, Object>) annotators.get(0)).get("class"));
+  }
+
+  @Test
+  public void mapInclude() throws IOException {
+    Yaml yaml = new IncludedYaml(new YamlFile(YamlFileTest.class, PARENT_INCLUDE_YAML), mapping);
+    String expected = getRaw(PARENT_INCLUDE_YAML);
     assertEquals(expected, yaml.original());
     Object data = yaml.dataTree();
     assertTrue(data instanceof Map);

--- a/baleen-core/src/test/resources/uk/gov/dstl/baleen/core/utils/yaml/parentInclude.yaml
+++ b/baleen-core/src/test/resources/uk/gov/dstl/baleen/core/utils/yaml/parentInclude.yaml
@@ -1,0 +1,9 @@
+
+include: reader.yaml
+
+annotators:
+  - include: child1.yaml
+  - class: uk.gov.dstl.baleen.testing.DummyAnnotator
+
+consumers:
+  - class: uk.gov.dstl.baleen.testing.DummyConsumer

--- a/baleen-core/src/test/resources/uk/gov/dstl/baleen/core/utils/yaml/reader.yaml
+++ b/baleen-core/src/test/resources/uk/gov/dstl/baleen/core/utils/yaml/reader.yaml
@@ -1,0 +1,3 @@
+
+collectionreader:
+  class: uk.gov.dstl.baleen.testing.RandomStringCollectionReader


### PR DESCRIPTION
This change allows map sections to be replace using the include. For example

```yaml

include: reader.yaml

annotators:
- class: uk.gov.dstl.baleen.testing.DummyAnnotator

consumers:
- class: uk.gov.dstl.baleen.testing.DummyConsumer

```

here the whole collection reader section can be included

```yaml
# reader.yaml
collectionreader:
  class: uk.gov.dstl.baleen.testing.RandomStringCollectionReader
```

The extends the previous implementaiton which only allowed list includes.
This should feel natural to the user and supports further nested includes.